### PR TITLE
Support bare git repos

### DIFF
--- a/src/ecosystem_analyzer/git.py
+++ b/src/ecosystem_analyzer/git.py
@@ -1,4 +1,52 @@
+import hashlib
+import logging
+from pathlib import Path
+
 from git import Commit, Repo
+
+from .installed_project import _get_cache_dir
+
+
+def _ty_repo_cache_path(repo_path: Path) -> Path:
+    cache_dir = _get_cache_dir()
+    repo_path = repo_path.resolve()
+    location_hash = hashlib.sha256(repo_path.as_posix().encode()).hexdigest()[:12]
+    return cache_dir / f"ty_{location_hash}"
+
+
+def _update_cached_repo(repo: Repo) -> None:
+    logging.debug("Updating cached ty repository")
+    repo.remote().fetch()
+
+
+def resolve_ty_repo(repo_path: str | Path) -> Repo:
+    """Return a Repo with a working tree, cloning bare repos into cache."""
+    resolved_path = Path(repo_path).expanduser().resolve()
+    repo = Repo(resolved_path)
+
+    if not repo.bare:
+        return repo
+
+    cache_path = _ty_repo_cache_path(resolved_path)
+
+    if cache_path.exists():
+        logging.info(f"Using cached ty repository at {cache_path}")
+        cached_repo = Repo(cache_path)
+    else:
+        logging.info(
+            f"Cloning bare ty repository from {resolved_path} to {cache_path}"
+        )
+        cached_repo = Repo.clone_from(resolved_path.as_posix(), cache_path)
+
+    try:
+        origin = cached_repo.remote()
+    except ValueError:
+        origin = cached_repo.create_remote("origin", resolved_path.as_posix())
+    else:
+        origin.set_url(resolved_path.as_posix())
+
+    _update_cached_repo(cached_repo)
+    return cached_repo
 
 
 def get_latest_ty_commits(repo: Repo, num_commits: int) -> list[Commit]:

--- a/src/ecosystem_analyzer/main.py
+++ b/src/ecosystem_analyzer/main.py
@@ -4,12 +4,10 @@ import sys
 from pathlib import Path
 
 import click
-from git import Repo
-
 from .diagnostic import DiagnosticsParser
 from .diff import DiagnosticDiff
 from .ecosystem_report import generate
-from .git import get_latest_ty_commits
+from .git import get_latest_ty_commits, resolve_ty_repo
 from .manager import Manager
 
 
@@ -42,7 +40,7 @@ def cli(ctx: click.Context, repository: str | None, verbose: bool) -> None:
     Command-line interface for analyzing Python projects with ty.
     """
     ctx.ensure_object(dict)
-    ctx.obj["repository"] = Repo(repository) if repository else None
+    ctx.obj["repository"] = resolve_ty_repo(repository) if repository else None
     ctx.obj["verbose"] = verbose
     setup_logging(verbose)
 


### PR DESCRIPTION
The `--repository` option points at a local clone of the `ty` repo. Until now, we've assumed that this is a non-bare clone, since we need a working directory to build and run `ty` from.

With this PR, we now support bare clones as well. We handle them by cloning them into a new non-bare repo in the same `~/.cache/ecosystem-analyzer` directory that we clone the analyzed projects into.