### PR TITLE
Parallelize project installation with ty build process

### DIFF
--- a/src/ecosystem_analyzer/main.py
+++ b/src/ecosystem_analyzer/main.py
@@ -249,14 +249,18 @@ def diff(
         flaky_projects=flaky_project_names,
     )
 
+    # Build old ty first — this overlaps with background project installation
+    manager.build(old)
+
     # Run for old commit with old projects
     manager.activate(project_names_old)
-    run_outputs_old = manager.run_for_commit(old)
+    run_outputs_old = manager.run_active_projects()
     manager.write_run_outputs(run_outputs_old, output_old)
 
-    # Run for new commit with new projects
+    # Run for new commit with new projects (incremental build, near-instant)
+    manager.build(new)
     manager.activate(project_names_new)
-    run_outputs_new = manager.run_for_commit(new)
+    run_outputs_new = manager.run_active_projects()
     manager.write_run_outputs(run_outputs_new, output_new)
 
 


### PR DESCRIPTION
## Summary

Claude reckons this should theoretically speed things up without damaging the integrity of the timings report. Seems plausible? Though I'm not sure how to test it empirically.

Here's Claude's summary below.

---

Refactor project installation to run in the background during the first ty build, reducing overall execution time by overlapping I/O-bound installation with compilation.

## Key Changes
- **Background installation**: Project installation now starts asynchronously in `__init__` via a `ThreadPoolExecutor` instead of blocking immediately
- **Deferred activation**: Default project activation is deferred until installation completes via new `_ensure_installed()` method
- **Build/run separation**: Split `run_for_commit()` into separate `build()` and `run_for_commit()` methods to allow building ty while projects install in parallel
- **New public API**: Added `run_active_projects()` to run the current build without rebuilding
- **Timing instrumentation**: Logs total installation time and how much overlapped with the build process
- **Updated workflow**: `main.py` now calls `build()` early to maximize overlap, then calls `run_active_projects()` after activation

## Implementation Details
- Installation happens in a single-worker thread pool to avoid resource contention
- `_ensure_installed()` blocks only when needed (before running or activating projects)
- The first `run_for_commit()` call still works as before but now benefits from background installation
- Subsequent builds are incremental and near-instant, allowing the second build to also overlap with any remaining installation

https://claude.ai/code/session_01QJGyRCkqhA5ZVGcFW4xZYH