### PR TITLE
Parallelize repeated runs of projects for flaky detection

### DIFF
--- a/src/ecosystem_analyzer/ty.py
+++ b/src/ecosystem_analyzer/ty.py
@@ -5,6 +5,7 @@ import subprocess
 import sys
 import time
 from collections import Counter
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 from git import Commit, Repo
@@ -136,43 +137,44 @@ class Ty:
     def run_on_project_multiple(self, project: InstalledProject, n: int) -> RunOutput:
         """Run ty on a project N times and classify diagnostics as stable/flaky.
 
-        Returns a single RunOutput where `diagnostics` contains only stable
-        diagnostics and `flaky_diagnostics` contains grouped flaky ones.
+        All N invocations run in parallel via ThreadPoolExecutor so that
+        wall-clock time is approximately that of a single run.
+
+        Returns a single RunOutput where ``diagnostics`` contains only stable
+        diagnostics and ``flaky_diagnostics`` contains grouped flaky ones.
         """
         assert n >= 2, "Use run_on_project for single runs"
         logger.info(
-            f"Running ty on project '{project.name}' {n} times for flaky detection"
+            f"Running ty on project '{project.name}' {n} times (parallel) for flaky detection"
         )
 
         all_diagnostics: list[list] = []
         times: list[float] = []
         return_codes: list[int | None] = []
 
-        for i in range(n):
-            logger.info(f"  Run {i + 1}/{n} for '{project.name}'")
-            output = self.run_on_project(project)
+        with ThreadPoolExecutor(max_workers=n) as executor:
+            futures = [executor.submit(self.run_on_project, project) for _ in range(n)]
+            outputs = [f.result() for f in futures]
 
-            # If any run fails abnormally, bail out and return the failure
-            if output.get("return_code") is not None and output["return_code"] not in (
-                0,
-                1,
-            ):
+        for idx, output in enumerate(outputs):
+            rc = output.get("return_code")
+            if rc is not None and rc not in (0, 1):
                 logger.warning(
-                    f"Run {i + 1}/{n} for '{project.name}' failed with return code "
-                    f"{output['return_code']}; aborting flaky detection"
+                    f"Run {idx + 1}/{n} for '{project.name}' failed with return "
+                    f"code {rc}; aborting flaky detection"
                 )
                 return output
-            if output.get("return_code") is None:
-                # Timeout
+            if rc is None:
                 logger.warning(
-                    f"Run {i + 1}/{n} for '{project.name}' timed out; aborting flaky detection"
+                    f"Run {idx + 1}/{n} for '{project.name}' timed out; "
+                    f"aborting flaky detection"
                 )
                 return output
 
             all_diagnostics.append(output["diagnostics"])
             if output.get("time_s") is not None:
                 times.append(output["time_s"])
-            return_codes.append(output.get("return_code"))
+            return_codes.append(rc)
 
         stable, flaky_locations = classify_diagnostics(all_diagnostics)
 


### PR DESCRIPTION
In general, we don't run ty in parallel in ecosystem-analyzer because we want to have ~reasonably accurate timing reports as well as diagnostic reports. But this concern doesn't apply for the reruns of projects that we do if we know that diagnostics are flaky on a particular project. Here we can execute multiple copies of ty in a threadpool, which should speedup ecosystem-analyzer a fair bit. (It's now [taking >18 minutes](https://github.com/astral-sh/ruff/actions/runs/22067223738?pr=23341) in Ruff's CI.)