### PR TITLE
Exclude flaky diagnostics from summary tables (but continue to list them in the HTML report)

### DIFF
--- a/src/ecosystem_analyzer/diff.py
+++ b/src/ecosystem_analyzer/diff.py
@@ -680,8 +680,16 @@ class DiagnosticDiff:
         diff = difflib.ndiff(old_text.splitlines(), new_text.splitlines())
         return list(diff)
 
-    def _calculate_statistics(self) -> DiffStatistics:
-        """Calculate statistics about added, removed, and changed diagnostics."""
+    def _calculate_statistics(
+        self, *, exclude_flaky: bool = False
+    ) -> DiffStatistics:
+        """Calculate statistics about added, removed, and changed diagnostics.
+
+        If *exclude_flaky* is True, flaky diagnostic diffs are excluded from
+        the per-lint and per-project tables as well as the totals.  Stable
+        diagnostics from projects that happen to also have flaky data are
+        still counted.
+        """
         # Intermediate dictionaries (local variables)
         added_by_lint: dict[str, int] = {}
         removed_by_lint: dict[str, int] = {}
@@ -795,44 +803,46 @@ class DiagnosticDiff:
                             removed_by_project.get(project_name, 0) + 1
                         )
 
-            # Count flaky location diffs (each location = 1 diagnostic)
-            flaky_diffs = project.get("flaky_diffs", {})
-            for loc in flaky_diffs.get("added", []):
-                total_added += 1
-                # Use the first variant's lint_name as representative
-                lint_name = (
-                    loc["variants"][0]["diagnostic"]["lint_name"]
-                    if loc["variants"]
-                    else "unknown"
-                )
-                added_by_lint[lint_name] = added_by_lint.get(lint_name, 0) + 1
-                added_by_project[project_name] = (
-                    added_by_project.get(project_name, 0) + 1
-                )
+            # Count flaky location diffs (each location = 1 diagnostic).
+            # When exclude_flaky is set, skip these entirely.
+            if not exclude_flaky:
+                flaky_diffs = project.get("flaky_diffs", {})
+                for loc in flaky_diffs.get("added", []):
+                    total_added += 1
+                    # Use the first variant's lint_name as representative
+                    lint_name = (
+                        loc["variants"][0]["diagnostic"]["lint_name"]
+                        if loc["variants"]
+                        else "unknown"
+                    )
+                    added_by_lint[lint_name] = added_by_lint.get(lint_name, 0) + 1
+                    added_by_project[project_name] = (
+                        added_by_project.get(project_name, 0) + 1
+                    )
 
-            for loc in flaky_diffs.get("removed", []):
-                total_removed += 1
-                lint_name = (
-                    loc["variants"][0]["diagnostic"]["lint_name"]
-                    if loc["variants"]
-                    else "unknown"
-                )
-                removed_by_lint[lint_name] = removed_by_lint.get(lint_name, 0) + 1
-                removed_by_project[project_name] = (
-                    removed_by_project.get(project_name, 0) + 1
-                )
+                for loc in flaky_diffs.get("removed", []):
+                    total_removed += 1
+                    lint_name = (
+                        loc["variants"][0]["diagnostic"]["lint_name"]
+                        if loc["variants"]
+                        else "unknown"
+                    )
+                    removed_by_lint[lint_name] = removed_by_lint.get(lint_name, 0) + 1
+                    removed_by_project[project_name] = (
+                        removed_by_project.get(project_name, 0) + 1
+                    )
 
-            for change in flaky_diffs.get("changed", []):
-                total_changed += 1
-                lint_name = (
-                    change["old"]["variants"][0]["diagnostic"]["lint_name"]
-                    if change["old"]["variants"]
-                    else "unknown"
-                )
-                changed_by_lint[lint_name] = changed_by_lint.get(lint_name, 0) + 1
-                changed_by_project[project_name] = (
-                    changed_by_project.get(project_name, 0) + 1
-                )
+                for change in flaky_diffs.get("changed", []):
+                    total_changed += 1
+                    lint_name = (
+                        change["old"]["variants"][0]["diagnostic"]["lint_name"]
+                        if change["old"]["variants"]
+                        else "unknown"
+                    )
+                    changed_by_lint[lint_name] = changed_by_lint.get(lint_name, 0) + 1
+                    changed_by_project[project_name] = (
+                        changed_by_project.get(project_name, 0) + 1
+                    )
 
         # Create merged lint breakdown sorted by total absolute change (descending)
         all_lints = (
@@ -1165,8 +1175,9 @@ class DiagnosticDiff:
         *,
         inline_threshold: int = 15,
         max_raw_diff_lines: int = 100,
+        exclude_flaky: bool = False,
     ) -> str:
-        statistics = self._calculate_statistics()
+        statistics = self._calculate_statistics(exclude_flaky=exclude_flaky)
         failed_projects = self.diffs.get("failed_projects", [])
 
         markdown_content = ""

--- a/src/ecosystem_analyzer/diff.py
+++ b/src/ecosystem_analyzer/diff.py
@@ -2,6 +2,7 @@ import difflib
 import json
 import os
 import random
+from itertools import chain
 from pathlib import Path
 from typing import Any, TypedDict
 
@@ -289,18 +290,16 @@ class DiagnosticDiff:
             new_failed, new_status = self._is_project_failed(new_project)
 
             if old_failed or new_failed:
-                result["failed_projects"].append(
-                    {
-                        "project": project_name,
-                        "project_location": new_project.get("project_location", ""),
-                        "old_status": old_status,
-                        "new_status": new_status,
-                        "old_return_code": old_project.get("return_code"),
-                        "new_return_code": new_project.get("return_code"),
-                        "old_panic_messages": old_project.get("panic_messages", []),
-                        "new_panic_messages": new_project.get("panic_messages", []),
-                    }
-                )
+                result["failed_projects"].append({
+                    "project": project_name,
+                    "project_location": new_project.get("project_location", ""),
+                    "old_status": old_status,
+                    "new_status": new_status,
+                    "old_return_code": old_project.get("return_code"),
+                    "new_return_code": new_project.get("return_code"),
+                    "old_panic_messages": old_project.get("panic_messages", []),
+                    "new_panic_messages": new_project.get("panic_messages", []),
+                })
                 # Skip detailed diff analysis for failed projects
                 continue
 
@@ -484,12 +483,10 @@ class DiagnosticDiff:
                         d.get("message", ""),
                     ),
                 )
-                result["removed_files"].append(
-                    {
-                        "path": file_path,
-                        "diagnostics": diagnostics,
-                    }
-                )
+                result["removed_files"].append({
+                    "path": file_path,
+                    "diagnostics": diagnostics,
+                })
 
         # Find added files
         for file_path in sorted(new_files.keys()):
@@ -504,12 +501,10 @@ class DiagnosticDiff:
                         d.get("message", ""),
                     ),
                 )
-                result["added_files"].append(
-                    {
-                        "path": file_path,
-                        "diagnostics": diagnostics,
-                    }
-                )
+                result["added_files"].append({
+                    "path": file_path,
+                    "diagnostics": diagnostics,
+                })
 
         # Find modified files
         for file_path in sorted(set(old_files.keys()) & set(new_files.keys())):
@@ -529,12 +524,10 @@ class DiagnosticDiff:
                 or line_diffs["removed_lines"]
                 or line_diffs["modified_lines"]
             ):
-                result["modified_files"].append(
-                    {
-                        "path": file_path,
-                        "diffs": line_diffs,
-                    }
-                )
+                result["modified_files"].append({
+                    "path": file_path,
+                    "diffs": line_diffs,
+                })
 
         return result
 
@@ -573,12 +566,10 @@ class DiagnosticDiff:
                     diagnostics,
                     key=lambda d: (d.get("column", 0), d.get("message", "")),
                 )
-                result["removed_lines"].append(
-                    {
-                        "line": line_num,
-                        "diagnostics": diagnostics,
-                    }
-                )
+                result["removed_lines"].append({
+                    "line": line_num,
+                    "diagnostics": diagnostics,
+                })
 
         # Find added lines
         for line_num in sorted(new_lines.keys()):
@@ -589,12 +580,10 @@ class DiagnosticDiff:
                     diagnostics,
                     key=lambda d: (d.get("column", 0), d.get("message", "")),
                 )
-                result["added_lines"].append(
-                    {
-                        "line": line_num,
-                        "diagnostics": diagnostics,
-                    }
-                )
+                result["added_lines"].append({
+                    "line": line_num,
+                    "diagnostics": diagnostics,
+                })
 
         # Find modified lines
         for line_num in sorted(set(old_lines.keys()) & set(new_lines.keys())):
@@ -632,13 +621,11 @@ class DiagnosticDiff:
                                 # Generate line diff
                                 diff = self._generate_text_diff(old_str, new_str)
                                 if diff:
-                                    text_diffs.append(
-                                        {
-                                            "old": old_diag,
-                                            "new": new_diag,
-                                            "diff": diff,
-                                        }
-                                    )
+                                    text_diffs.append({
+                                        "old": old_diag,
+                                        "new": new_diag,
+                                        "diff": diff,
+                                    })
                                     changed_old_formatted.add(old_str)
                                     changed_new_formatted.add(new_str)
                                     matched_new_strs.add(new_str)
@@ -667,14 +654,12 @@ class DiagnosticDiff:
                     key=lambda d: (d.get("column", 0), d.get("message", "")),
                 )
 
-                result["modified_lines"].append(
-                    {
-                        "line": line_num,
-                        "removed": removed_diagnostics,
-                        "added": added_diagnostics,
-                        "text_diffs": text_diffs,
-                    }
-                )
+                result["modified_lines"].append({
+                    "line": line_num,
+                    "removed": removed_diagnostics,
+                    "added": added_diagnostics,
+                    "text_diffs": text_diffs,
+                })
 
         return result
 
@@ -823,16 +808,14 @@ class DiagnosticDiff:
             removed_count = removed_by_lint.get(lint_name, 0)
             changed_count = changed_by_lint.get(lint_name, 0)
             total_change = added_count + removed_count + changed_count
-            merged_lints.append(
-                {
-                    "lint_name": lint_name,
-                    "added": added_count,
-                    "removed": removed_count,
-                    "changed": changed_count,
-                    "net_change": added_count - removed_count,
-                    "total_change": total_change,
-                }
-            )
+            merged_lints.append({
+                "lint_name": lint_name,
+                "added": added_count,
+                "removed": removed_count,
+                "changed": changed_count,
+                "net_change": added_count - removed_count,
+                "total_change": total_change,
+            })
 
         # Sort by total absolute change (|removed| + |added| + |changed|) descending, then by name for ties
         merged_lints.sort(key=lambda x: (-x["total_change"], x["lint_name"]))
@@ -850,16 +833,14 @@ class DiagnosticDiff:
             removed_count = removed_by_project.get(project_name, 0)
             changed_count = changed_by_project.get(project_name, 0)
             total_change = added_count + removed_count + changed_count
-            merged_projects.append(
-                {
-                    "project_name": project_name,
-                    "added": added_count,
-                    "removed": removed_count,
-                    "changed": changed_count,
-                    "net_change": added_count - removed_count,
-                    "total_change": total_change,
-                }
-            )
+            merged_projects.append({
+                "project_name": project_name,
+                "added": added_count,
+                "removed": removed_count,
+                "changed": changed_count,
+                "net_change": added_count - removed_count,
+                "total_change": total_change,
+            })
 
         # Sort by total absolute change (|removed| + |added| + |changed|) descending, then by name for ties
         merged_projects.sort(key=lambda x: (-x["total_change"], x["project_name"]))
@@ -955,20 +936,6 @@ class DiagnosticDiff:
             title += ": new panics/timeouts detected ❌"
         return title
 
-    def _format_flaky_location(self, loc: dict) -> str:
-        variants = " | ".join(
-            self._format_short_diagnostic(variant["diagnostic"])
-            for variant in loc["variants"]
-        )
-        return f"{loc['path']}:{loc['line']}:{loc['column']} {{{variants}}}"
-
-    def _project_header(
-        self, project_name: str, project_location: str | None
-    ) -> str:
-        if project_location:
-            return f"{project_name} ({project_location})"
-        return project_name
-
     def _render_raw_diff_sections(
         self, sections: dict[str, list[tuple[list[str], bool]]]
     ) -> list[str]:
@@ -984,25 +951,41 @@ class DiagnosticDiff:
 
         return lines
 
+    def _has_flaky_diagnostics(self) -> bool:
+        """Check whether any flaky diagnostics were omitted from the raw diff."""
+        if any(
+            project.get("flaky_diagnostics")
+            for project in chain(
+                self.diffs["removed_projects"], self.diffs["added_projects"]
+            )
+        ):
+            return True
+        for project in self.diffs["modified_projects"]:
+            flaky_diffs = project.get("flaky_diffs", {})
+            if (
+                flaky_diffs.get("added")
+                or flaky_diffs.get("removed")
+                or flaky_diffs.get("changed")
+            ):
+                return True
+        return False
+
     def _raw_diff_sections(
         self,
     ) -> tuple[dict[str, list[tuple[list[str], bool]]], int, bool]:
         sections: dict[str, list[tuple[list[str], bool]]] = {}
-        omitted_flaky_diagnostics = False
 
         def add_entry(
             project_name: str,
             project_location: str | None,
             lines: list[str],
             *,
-            is_flaky: bool = False,
             counts_as_change: bool = True,
         ) -> None:
-            nonlocal omitted_flaky_diagnostics
-            if is_flaky:
-                omitted_flaky_diagnostics = True
-                return
-            header = self._project_header(project_name, project_location)
+            if project_location:
+                header = f"{project_name} ({project_location})"
+            else:
+                header = project_name
             sections.setdefault(header, []).append((lines, counts_as_change))
 
         for project in self.diffs["failed_projects"]:
@@ -1026,14 +1009,6 @@ class DiagnosticDiff:
                     project_location,
                     [f"- {self._format_short_diagnostic(diag)}"],
                 )
-            for loc in project.get("flaky_diagnostics", []):
-                add_entry(
-                    project_name,
-                    project_location,
-                    [f"- {self._format_flaky_location(loc)}"],
-                    is_flaky=True,
-                )
-
         for project in self.diffs["added_projects"]:
             project_name = project["project"]
             project_location = project.get("project_location")
@@ -1043,14 +1018,6 @@ class DiagnosticDiff:
                     project_location,
                     [f"+ {self._format_short_diagnostic(diag)}"],
                 )
-            for loc in project.get("flaky_diagnostics", []):
-                add_entry(
-                    project_name,
-                    project_location,
-                    [f"+ {self._format_flaky_location(loc)}"],
-                    is_flaky=True,
-                )
-
         for project in self.diffs["modified_projects"]:
             project_name = project["project"]
             project_location = project.get("project_location")
@@ -1112,41 +1079,13 @@ class DiagnosticDiff:
                             [f"+ {self._format_short_diagnostic(diag)}"],
                         )
 
-            flaky_diffs = project.get("flaky_diffs", {})
-            for loc in flaky_diffs.get("removed", []):
-                add_entry(
-                    project_name,
-                    project_location,
-                    [f"- {self._format_flaky_location(loc)}"],
-                    is_flaky=True,
-                )
-
-            for loc in flaky_diffs.get("added", []):
-                add_entry(
-                    project_name,
-                    project_location,
-                    [f"+ {self._format_flaky_location(loc)}"],
-                    is_flaky=True,
-                )
-
-            for change in flaky_diffs.get("changed", []):
-                add_entry(
-                    project_name,
-                    project_location,
-                    [
-                        f"- {self._format_flaky_location(change['old'])}",
-                        f"+ {self._format_flaky_location(change['new'])}",
-                    ],
-                    is_flaky=True,
-                )
-
         total_changes = sum(
             1
             for entries in sections.values()
             for _lines, counts_as_change in entries
             if counts_as_change
         )
-        return sections, total_changes, omitted_flaky_diagnostics
+        return sections, total_changes, self._has_flaky_diagnostics()
 
     def render_statistics_markdown(
         self,
@@ -1217,12 +1156,12 @@ class DiagnosticDiff:
                     f"{row['new_time']:.2f}s | {row['change_percent']:+.0f}% |\n"
                 )
 
-        raw_diff_sections, total_raw_diff_changes, omitted_flaky_diagnostics = (
+        raw_diff_sections, total_raw_diff_changes, has_flaky_diagnostics = (
             self._raw_diff_sections()
         )
         raw_diff_lines = self._render_raw_diff_sections(raw_diff_sections)
 
-        if omitted_flaky_diagnostics:
+        if has_flaky_diagnostics:
             markdown_content += (
                 "\n\n_Changes in flaky projects detected. "
                 "This PR summary excludes flaky changes; see the HTML report for details._"
@@ -1485,22 +1424,20 @@ class DiagnosticDiff:
                 is_failed = False
                 failure_type = None
 
-            timing_data.append(
-                {
-                    "project": project_name,
-                    "old_time": old_time,
-                    "new_time": new_time,
-                    "old_return_code": old_return_code,
-                    "new_return_code": new_return_code,
-                    "factor": factor,
-                    "is_failed": is_failed,
-                    "failure_type": failure_type,
-                    "old_is_timeout": old_is_timeout,
-                    "new_is_timeout": new_is_timeout,
-                    "old_is_abnormal": old_is_abnormal,
-                    "new_is_abnormal": new_is_abnormal,
-                }
-            )
+            timing_data.append({
+                "project": project_name,
+                "old_time": old_time,
+                "new_time": new_time,
+                "old_return_code": old_return_code,
+                "new_return_code": new_return_code,
+                "factor": factor,
+                "is_failed": is_failed,
+                "failure_type": failure_type,
+                "old_is_timeout": old_is_timeout,
+                "new_is_timeout": new_is_timeout,
+                "old_is_abnormal": old_is_abnormal,
+                "new_is_abnormal": new_is_abnormal,
+            })
 
         # Sort by failure type first (abnormal exits, then timeouts, then normal), then by factor significance
         def sort_key(x):
@@ -1576,15 +1513,13 @@ class DiagnosticDiff:
             if old_time is None or new_time is None:
                 continue
 
-            large_changes.append(
-                {
-                    "project": row["project"],
-                    "old_time": old_time,
-                    "new_time": new_time,
-                    "factor": factor,
-                    "change_percent": (factor - 1.0) * 100,
-                }
-            )
+            large_changes.append({
+                "project": row["project"],
+                "old_time": old_time,
+                "new_time": new_time,
+                "factor": factor,
+                "change_percent": (factor - 1.0) * 100,
+            })
 
         large_changes.sort(key=lambda row: abs(row["factor"] - 1.0), reverse=True)
         return large_changes

--- a/src/ecosystem_analyzer/diff.py
+++ b/src/ecosystem_analyzer/diff.py
@@ -857,22 +857,7 @@ class DiagnosticDiff:
                 project_data["project_name"] in flaky_project_names
             )
 
-        # Add projects that are flaky but have no diffstat changes
-        projects_in_merged = {p["project_name"] for p in merged_projects}
-        merged_projects.extend(
-            {
-                "project_name": project_name,
-                "added": 0,
-                "removed": 0,
-                "changed": 0,
-                "net_change": 0,
-                "total_change": 0,
-                "is_flaky": True,
-            }
-            for project_name in sorted(flaky_project_names - projects_in_merged)
-        )
-
-        # Re-sort: flaky-only projects (0 total change) go last
+        # Sort by total absolute change (|removed| + |added| + |changed|) descending, then by name for ties
         merged_projects.sort(key=lambda x: (-x["total_change"], x["project_name"]))
 
         return {
@@ -1163,7 +1148,7 @@ class DiagnosticDiff:
 
         if has_flaky_diagnostics:
             markdown_content += (
-                "\n\n_Changes in flaky projects detected. "
+                "\n\n_Flaky changes detected. "
                 "This PR summary excludes flaky changes; see the HTML report for details._"
             )
 

--- a/src/ecosystem_analyzer/diff.py
+++ b/src/ecosystem_analyzer/diff.py
@@ -675,9 +675,9 @@ class DiagnosticDiff:
     def _calculate_statistics(self) -> DiffStatistics:
         """Calculate statistics about added, removed, and changed diagnostics.
 
-        Flaky diagnostic diffs are excluded from the per-lint and per-project
-        tables as well as the totals.  Stable diagnostics from projects that
-        happen to also have flaky data are still counted.
+        Flaky diagnostic diffs are excluded from the totals and breakdowns.
+        Stable diagnostics from projects that happen to also have flaky data
+        are still counted.
         """
         # Intermediate dictionaries (local variables)
         added_by_lint: dict[str, int] = {}
@@ -851,14 +851,11 @@ class DiagnosticDiff:
             if output.get("flaky_diagnostics"):
                 flaky_project_names.add(output["project"])
 
-        # Add flaky label to project entries, and include flaky-only projects
+        # Add flaky label to project entries
         for project_data in merged_projects:
             project_data["is_flaky"] = (
                 project_data["project_name"] in flaky_project_names
             )
-
-        # Sort by total absolute change (|removed| + |added| + |changed|) descending, then by name for ties
-        merged_projects.sort(key=lambda x: (-x["total_change"], x["project_name"]))
 
         return {
             "total_added": total_added,
@@ -957,7 +954,7 @@ class DiagnosticDiff:
 
     def _raw_diff_sections(
         self,
-    ) -> tuple[dict[str, list[tuple[list[str], bool]]], int, bool]:
+    ) -> tuple[dict[str, list[tuple[list[str], bool]]], int]:
         sections: dict[str, list[tuple[list[str], bool]]] = {}
 
         def add_entry(
@@ -1070,7 +1067,7 @@ class DiagnosticDiff:
             for _lines, counts_as_change in entries
             if counts_as_change
         )
-        return sections, total_changes, self._has_flaky_diagnostics()
+        return sections, total_changes
 
     def render_statistics_markdown(
         self,
@@ -1141,12 +1138,10 @@ class DiagnosticDiff:
                     f"{row['new_time']:.2f}s | {row['change_percent']:+.0f}% |\n"
                 )
 
-        raw_diff_sections, total_raw_diff_changes, has_flaky_diagnostics = (
-            self._raw_diff_sections()
-        )
+        raw_diff_sections, total_raw_diff_changes = self._raw_diff_sections()
         raw_diff_lines = self._render_raw_diff_sections(raw_diff_sections)
 
-        if has_flaky_diagnostics:
+        if self._has_flaky_diagnostics():
             markdown_content += (
                 "\n\n_Flaky changes detected. "
                 "This PR summary excludes flaky changes; see the HTML report for details._"

--- a/src/ecosystem_analyzer/diff.py
+++ b/src/ecosystem_analyzer/diff.py
@@ -1246,10 +1246,24 @@ class DiagnosticDiff:
         )
         raw_diff_lines = self._render_raw_diff_sections(raw_diff_sections)
 
-        if omitted_flaky_projects:
+        # Check whether any flaky diagnostic diffs were excluded from the
+        # summary table so we can tell the reader.
+        excluded_flaky_from_table = False
+        if exclude_flaky:
+            for project in self.diffs["modified_projects"]:
+                flaky_diffs = project.get("flaky_diffs", {})
+                if (
+                    flaky_diffs.get("added")
+                    or flaky_diffs.get("removed")
+                    or flaky_diffs.get("changed")
+                ):
+                    excluded_flaky_from_table = True
+                    break
+
+        if omitted_flaky_projects or excluded_flaky_from_table:
             markdown_content += (
                 "\n\n_Changes in flaky projects detected. "
-                "Raw diff output excludes flaky projects; see the HTML report for details._"
+                "This PR summary excludes flaky changes; see the HTML report for details._"
             )
 
         if not raw_diff_lines:

--- a/src/ecosystem_analyzer/main.py
+++ b/src/ecosystem_analyzer/main.py
@@ -520,6 +520,12 @@ def generate_timing_diff(
     show_default=True,
     help="Exit with a non-zero status if a project regresses from exit code 0/1 to another exit code or a timeout.",
 )
+@click.option(
+    "--exclude-flaky/--no-exclude-flaky",
+    default=False,
+    show_default=True,
+    help="Exclude flaky diagnostics from the summary table.",
+)
 def generate_diff_statistics(
     old_file: str,
     new_file: str,
@@ -529,6 +535,7 @@ def generate_diff_statistics(
     old_name: str | None,
     new_name: str | None,
     fail_on_new_abnormal_exits: bool,
+    exclude_flaky: bool,
 ) -> None:
     """
     Generate a Markdown statistics report of diagnostic differences between two JSON files.
@@ -540,6 +547,7 @@ def generate_diff_statistics(
     markdown_content = diff.render_statistics_markdown(
         inline_threshold=inline_threshold,
         max_raw_diff_lines=max_raw_diff_lines,
+        exclude_flaky=exclude_flaky,
     )
 
     with open(output, "w") as f:

--- a/tests/test_json_roundtrip.py
+++ b/tests/test_json_roundtrip.py
@@ -102,42 +102,6 @@ class TestJsonRoundtrip:
         assert stats["total_added"] == 0
         assert stats["total_removed"] == 0
 
-    def test_flaky_added_excluded_from_statistics(self):
-        """A new flaky location is excluded from statistics."""
-        diag = {
-            "level": "error",
-            "lint_name": "some-lint",
-            "path": "a.py",
-            "line": 1,
-            "column": 1,
-            "message": "stable",
-        }
-        new_flaky = [
-            _make_flaky_loc(
-                "b.py",
-                10,
-                1,
-                [
-                    _make_variant("b.py", 10, 1, "variant A", count=2),
-                    _make_variant("b.py", 10, 1, "variant B", count=1),
-                ],
-            )
-        ]
-
-        old_data = {"outputs": [_make_output("proj", [diag])]}
-        new_data = {"outputs": [_make_output("proj", [diag], new_flaky, flaky_runs=3)]}
-
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f1:
-            json.dump(old_data, f1)
-            old_path = f1.name
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f2:
-            json.dump(new_data, f2)
-            new_path = f2.name
-
-        diff = DiagnosticDiff(old_path, new_path)
-        stats = diff._calculate_statistics()
-        assert stats["total_added"] == 0  # Flaky location excluded from stats
-
     def test_flaky_same_location_different_variants_suppressed(self):
         """Flaky locations at the same position are suppressed even with different variants."""
         diag = {
@@ -183,41 +147,6 @@ class TestJsonRoundtrip:
         assert stats["total_changed"] == 0
         assert stats["total_added"] == 0
         assert stats["total_removed"] == 0
-
-    def test_flaky_genuinely_new_location_excluded_from_statistics(self):
-        """A genuinely new flaky location is excluded from statistics."""
-        diag = {
-            "level": "error",
-            "lint_name": "some-lint",
-            "path": "a.py",
-            "line": 1,
-            "column": 1,
-            "message": "stable",
-        }
-        new_flaky = [
-            _make_flaky_loc(
-                "c.py",
-                50,
-                1,
-                [
-                    _make_variant("c.py", 50, 1, "new variant", count=2),
-                ],
-            )
-        ]
-
-        old_data = {"outputs": [_make_output("proj", [diag])]}
-        new_data = {"outputs": [_make_output("proj", [diag], new_flaky, flaky_runs=3)]}
-
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f1:
-            json.dump(old_data, f1)
-            old_path = f1.name
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f2:
-            json.dump(new_data, f2)
-            new_path = f2.name
-
-        diff = DiagnosticDiff(old_path, new_path)
-        stats = diff._calculate_statistics()
-        assert stats["total_added"] == 0
 
     def test_flaky_diffs_organized_by_file(self):
         """Flaky diffs are organized by file path for inline rendering."""

--- a/tests/test_json_roundtrip.py
+++ b/tests/test_json_roundtrip.py
@@ -412,6 +412,49 @@ class TestJsonRoundtrip:
         stats = diff._calculate_statistics()
         assert stats["total_added"] == 1
 
+    def test_flaky_only_project_absent_from_project_breakdown(self):
+        """A project whose only changes are flaky does not appear in merged_by_project."""
+        diag = {
+            "level": "error",
+            "lint_name": "some-lint",
+            "path": "a.py",
+            "line": 1,
+            "column": 1,
+            "message": "stable",
+        }
+        new_flaky = [
+            _make_flaky_loc(
+                "b.py", 5, 1, [_make_variant("b.py", 5, 1, "flaky msg", count=2)]
+            )
+        ]
+
+        # "stable_proj" has a real diagnostic change; "flaky_proj" only has flaky changes.
+        old_data = {
+            "outputs": [
+                _make_output("stable_proj", [diag]),
+                _make_output("flaky_proj", [diag]),
+            ]
+        }
+        new_data = {
+            "outputs": [
+                _make_output("stable_proj", []),
+                _make_output("flaky_proj", [diag], new_flaky, flaky_runs=3),
+            ]
+        }
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f1:
+            json.dump(old_data, f1)
+            old_path = f1.name
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f2:
+            json.dump(new_data, f2)
+            new_path = f2.name
+
+        diff = DiagnosticDiff(old_path, new_path)
+        stats = diff._calculate_statistics()
+        project_names = [p["project_name"] for p in stats["merged_by_project"]]
+        assert "stable_proj" in project_names
+        assert "flaky_proj" not in project_names
+
     def test_flaky_notice_shown_when_flaky_diagnostics_present(self):
         """The rendered markdown includes a notice when flaky diagnostics were excluded."""
         diag = {

--- a/tests/test_json_roundtrip.py
+++ b/tests/test_json_roundtrip.py
@@ -395,6 +395,98 @@ class TestJsonRoundtrip:
         assert "| `slow-project` | 10.00s | 15.00s | +50% |" in markdown
         assert "| `very-fast-project` | 10.00s | 5.00s | -50% |" in markdown
 
+    def test_exclude_flaky_omits_only_flaky_diffs_from_statistics(self):
+        """With exclude_flaky, flaky diffs are excluded but stable diffs from the same project are kept."""
+        stable_diag = {
+            "level": "error",
+            "lint_name": "some-lint",
+            "path": "a.py",
+            "line": 1,
+            "column": 1,
+            "message": "stable",
+        }
+        new_stable_diag = {
+            "level": "error",
+            "lint_name": "some-lint",
+            "path": "a.py",
+            "line": 2,
+            "column": 1,
+            "message": "new stable diagnostic",
+        }
+        # Flaky location only on new side (genuinely new flaky location)
+        new_flaky = [
+            _make_flaky_loc(
+                "c.py", 50, 1, [_make_variant("c.py", 50, 1, "flaky variant", count=2)]
+            )
+        ]
+
+        old_data = {"outputs": [_make_output("proj", [stable_diag])]}
+        new_data = {
+            "outputs": [
+                _make_output(
+                    "proj", [stable_diag, new_stable_diag], new_flaky, flaky_runs=3
+                )
+            ]
+        }
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f1:
+            json.dump(old_data, f1)
+            old_path = f1.name
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f2:
+            json.dump(new_data, f2)
+            new_path = f2.name
+
+        diff = DiagnosticDiff(old_path, new_path)
+
+        # Without exclude_flaky: 1 stable added + 1 flaky added = 2
+        stats = diff._calculate_statistics(exclude_flaky=False)
+        assert stats["total_added"] == 2
+
+        # With exclude_flaky: only the stable diagnostic is counted
+        stats_excl = diff._calculate_statistics(exclude_flaky=True)
+        assert stats_excl["total_added"] == 1
+        lint_entry = next(
+            e for e in stats_excl["merged_by_lint"] if e["lint_name"] == "some-lint"
+        )
+        assert lint_entry["added"] == 1
+
+    def test_exclude_flaky_keeps_stable_diffs_from_flaky_projects(self):
+        """Stable diagnostic changes from a project with flaky_runs > 1 are still counted."""
+        diag = {
+            "level": "error",
+            "lint_name": "some-lint",
+            "path": "a.py",
+            "line": 1,
+            "column": 1,
+            "message": "msg",
+        }
+        new_diag = {
+            "level": "error",
+            "lint_name": "some-lint",
+            "path": "a.py",
+            "line": 2,
+            "column": 1,
+            "message": "new msg",
+        }
+
+        # Project has flaky_runs=5 but no flaky_diagnostics — the stable
+        # diagnostic change should still be counted even with exclude_flaky.
+        old_data = {"outputs": [_make_output("proj", [diag], flaky_runs=5)]}
+        new_data = {
+            "outputs": [_make_output("proj", [diag, new_diag], flaky_runs=5)]
+        }
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f1:
+            json.dump(old_data, f1)
+            old_path = f1.name
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f2:
+            json.dump(new_data, f2)
+            new_path = f2.name
+
+        diff = DiagnosticDiff(old_path, new_path)
+        stats = diff._calculate_statistics(exclude_flaky=True)
+        assert stats["total_added"] == 1
+
     def test_statistics_markdown_omits_small_or_failed_timing_changes(self):
         old_data = {
             "outputs": [

--- a/tests/test_json_roundtrip.py
+++ b/tests/test_json_roundtrip.py
@@ -520,6 +520,118 @@ class TestJsonRoundtrip:
         markdown = diff.render_statistics_markdown()
         assert "flaky" not in markdown.lower()
 
+    def test_flaky_entries_excluded_from_raw_diff_output(self):
+        """Flaky diagnostic messages do not appear in the rendered markdown raw diff."""
+        stable_diag = {
+            "level": "error",
+            "lint_name": "some-lint",
+            "path": "a.py",
+            "line": 1,
+            "column": 1,
+            "message": "stable message",
+        }
+        new_stable_diag = {
+            "level": "error",
+            "lint_name": "some-lint",
+            "path": "a.py",
+            "line": 2,
+            "column": 1,
+            "message": "new stable message",
+        }
+        new_flaky = [
+            _make_flaky_loc(
+                "b.py",
+                5,
+                1,
+                [_make_variant("b.py", 5, 1, "flaky variant msg", count=2)],
+            )
+        ]
+
+        old_data = {"outputs": [_make_output("proj", [stable_diag])]}
+        new_data = {
+            "outputs": [
+                _make_output(
+                    "proj", [stable_diag, new_stable_diag], new_flaky, flaky_runs=3
+                )
+            ]
+        }
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f1:
+            json.dump(old_data, f1)
+            old_path = f1.name
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f2:
+            json.dump(new_data, f2)
+            new_path = f2.name
+
+        diff = DiagnosticDiff(old_path, new_path)
+        markdown = diff.render_statistics_markdown()
+
+        # The stable diagnostic should appear in the raw diff
+        assert "new stable message" in markdown
+        # The flaky diagnostic should NOT appear in the raw diff
+        assert "flaky variant msg" not in markdown
+
+    def test_added_project_with_only_flaky_diagnostics(self):
+        """An added project with only flaky diagnostics produces zero stats and shows the notice."""
+        flaky = [
+            _make_flaky_loc(
+                "a.py", 1, 1, [_make_variant("a.py", 1, 1, "flaky only msg", count=3)]
+            )
+        ]
+
+        old_data = {"outputs": []}
+        new_data = {"outputs": [_make_output("new_proj", [], flaky, flaky_runs=3)]}
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f1:
+            json.dump(old_data, f1)
+            old_path = f1.name
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f2:
+            json.dump(new_data, f2)
+            new_path = f2.name
+
+        diff = DiagnosticDiff(old_path, new_path)
+        stats = diff._calculate_statistics()
+        assert stats["total_added"] == 0
+        assert stats["total_removed"] == 0
+        project_names = [p["project_name"] for p in stats["merged_by_project"]]
+        assert "new_proj" not in project_names
+
+        markdown = diff.render_statistics_markdown()
+        assert "excludes flaky changes" in markdown
+        assert "flaky only msg" not in markdown
+
+    def test_removed_project_with_only_flaky_diagnostics(self):
+        """A removed project with only flaky diagnostics produces zero stats and shows the notice."""
+        flaky = [
+            _make_flaky_loc(
+                "a.py",
+                1,
+                1,
+                [_make_variant("a.py", 1, 1, "removed flaky msg", count=2)],
+            )
+        ]
+
+        old_data = {"outputs": [_make_output("old_proj", [], flaky, flaky_runs=3)]}
+        new_data = {"outputs": []}
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f1:
+            json.dump(old_data, f1)
+            old_path = f1.name
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f2:
+            json.dump(new_data, f2)
+            new_path = f2.name
+
+        diff = DiagnosticDiff(old_path, new_path)
+        stats = diff._calculate_statistics()
+        assert stats["total_added"] == 0
+        assert stats["total_removed"] == 0
+        project_names = [p["project_name"] for p in stats["merged_by_project"]]
+        assert "old_proj" not in project_names
+
+        markdown = diff.render_statistics_markdown()
+        assert "excludes flaky changes" in markdown
+        assert "removed flaky msg" not in markdown
+
     def test_statistics_markdown_omits_small_or_failed_timing_changes(self):
         old_data = {
             "outputs": [

--- a/tests/test_json_roundtrip.py
+++ b/tests/test_json_roundtrip.py
@@ -412,6 +412,71 @@ class TestJsonRoundtrip:
         stats = diff._calculate_statistics()
         assert stats["total_added"] == 1
 
+    def test_flaky_notice_shown_when_flaky_diagnostics_present(self):
+        """The rendered markdown includes a notice when flaky diagnostics were excluded."""
+        diag = {
+            "level": "error",
+            "lint_name": "some-lint",
+            "path": "a.py",
+            "line": 1,
+            "column": 1,
+            "message": "stable",
+        }
+        new_flaky = [
+            _make_flaky_loc(
+                "b.py", 5, 1, [_make_variant("b.py", 5, 1, "flaky msg", count=2)]
+            )
+        ]
+
+        old_data = {"outputs": [_make_output("proj", [diag])]}
+        new_data = {
+            "outputs": [_make_output("proj", [diag], new_flaky, flaky_runs=3)]
+        }
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f1:
+            json.dump(old_data, f1)
+            old_path = f1.name
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f2:
+            json.dump(new_data, f2)
+            new_path = f2.name
+
+        diff = DiagnosticDiff(old_path, new_path)
+        markdown = diff.render_statistics_markdown()
+        assert "excludes flaky changes" in markdown
+
+    def test_flaky_notice_absent_when_no_flaky_diagnostics(self):
+        """The rendered markdown omits the flaky notice when there are no flaky diagnostics."""
+        diag = {
+            "level": "error",
+            "lint_name": "some-lint",
+            "path": "a.py",
+            "line": 1,
+            "column": 1,
+            "message": "stable",
+        }
+        new_diag = {
+            "level": "error",
+            "lint_name": "some-lint",
+            "path": "a.py",
+            "line": 2,
+            "column": 1,
+            "message": "new stable",
+        }
+
+        old_data = {"outputs": [_make_output("proj", [diag])]}
+        new_data = {"outputs": [_make_output("proj", [diag, new_diag])]}
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f1:
+            json.dump(old_data, f1)
+            old_path = f1.name
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f2:
+            json.dump(new_data, f2)
+            new_path = f2.name
+
+        diff = DiagnosticDiff(old_path, new_path)
+        markdown = diff.render_statistics_markdown()
+        assert "flaky" not in markdown.lower()
+
     def test_statistics_markdown_omits_small_or_failed_timing_changes(self):
         old_data = {
             "outputs": [


### PR DESCRIPTION
## Summary

This PR adds an `--exclude-flaky` flag that excludes flaky diagnostics from the summary table posted as comments on PRs. I don't much care if a PR added 40 `invalid-await` diagnostics if the diagnostics are on a known-flaky project and all 40 `invalid-await` diagnostics were in fact detected as being flaky by ecosystem-analyzer; it's annoying to have to click through to the HTML report to be able to see that those 40 diagnostics were in fact all flaky diagnostics on prefect.

We want to know if any diagnostics are _newly flaky_ or _newly not flaky_ -- but Doug's experiments showed that running a flaky project 10 times (what we do in CI for ty PRs) isn't generally enough to be able to establish that. And anyway, we only run flaky detection in PR CI for known-flaky projects.

I propose that we run ecosystem-analyzer in CI on PRs with this new `--exclude-flaky` flag. The weekly run of ecosystem-analyzer, where we run flaky-diagnostic detection across the whole ecosystem and run with `--flaky-runs=20`, can continue to be run without this flag, so that we can still have a way of empirically establishing whether any flaky diagnostics were newly added or removed.

This is one of the ideas mentioned in https://github.com/astral-sh/ecosystem-analyzer/issues/11