### PR TITLE
Add on hover details to project summary flaky tags

### DIFF
--- a/src/ecosystem_analyzer/templates/diff.html
+++ b/src/ecosystem_analyzer/templates/diff.html
@@ -601,7 +601,7 @@
                             </tr>
                             {% for project_data in statistics.merged_by_project[:20] %}
                             <tr>
-                                <td>{{ project_data.project_name }}{% if project_data.is_flaky %} <span class="flaky-badge">flaky</span>{% endif %}</td>
+                                <td>{{ project_data.project_name }}{% if project_data.is_flaky %} <span class="flaky-badge" title="Flaky: nondeterministic diagnostics across multiple runs">flaky</span>{% endif %}</td>
                                 <td class="removed-col">{{ project_data.removed }}</td>
                                 <td class="added-col">{{ project_data.added }}</td>
                                 <td class="changed-col">{{ project_data.changed }}</td>
@@ -610,7 +610,7 @@
                             {% if statistics.merged_by_project|length > 20 %}
                             {% for project_data in statistics.merged_by_project[20:] %}
                             <tr class="project-row-hidden" style="display: none;">
-                                <td>{{ project_data.project_name }}{% if project_data.is_flaky %} <span class="flaky-badge">flaky</span>{% endif %}</td>
+                                <td>{{ project_data.project_name }}{% if project_data.is_flaky %} <span class="flaky-badge" title="Flaky: nondeterministic diagnostics across multiple runs">flaky</span>{% endif %}</td>
                                 <td class="removed-col">{{ project_data.removed }}</td>
                                 <td class="added-col">{{ project_data.added }}</td>
                                 <td class="changed-col">{{ project_data.changed }}</td>


### PR DESCRIPTION
While looking at the reports I noticed there is no on hover text for the flaky tags on the project summary section, so this PR adds it.