### PR TITLE
Add an `--exclude-newer` flag

### DIFF
--- a/src/ecosystem_analyzer/diagnostic.py
+++ b/src/ecosystem_analyzer/diagnostic.py
@@ -2,7 +2,6 @@ import re
 from pathlib import Path
 from typing import NotRequired, TypedDict
 
-
 OLD_DIAGNOSTIC_PATTERN = re.compile(
     r"^(?P<level>error|warning|fatal)\[(?P<lint_name>.+?)\] "
     r"(?P<path>.+?):(?P<line>\d+):(?P<column>\d+): "

--- a/src/ecosystem_analyzer/installed_project.py
+++ b/src/ecosystem_analyzer/installed_project.py
@@ -1,3 +1,4 @@
+import datetime as dt
 import hashlib
 import logging
 import os
@@ -34,13 +35,41 @@ def _get_project_cache_path(project: Project) -> Path:
     return cache_dir / f"{project_name}_{location_hash}"
 
 
+def validate_exclude_newer(value: str) -> dt.datetime:
+    """Validate and parse an ISO 8601 timestamp for --exclude-newer.
+
+    Returns a timezone-aware UTC datetime.
+
+    Raises ValueError if the timestamp cannot be parsed or is missing timezone info.
+    """
+    try:
+        res = dt.datetime.fromisoformat(value)
+    except ValueError as e:
+        raise ValueError(
+            f"Invalid --exclude-newer timestamp: {value!r}. "
+            f"Expected an ISO 8601 timestamp (e.g. '2026-04-09T10:00:00Z')."
+        ) from e
+
+    if res.tzinfo is None:
+        raise ValueError(
+            f"--exclude-newer timestamp {value!r} is missing timezone info. "
+            f"Use a UTC timestamp like '2026-04-09T10:00:00Z'."
+        )
+
+    return res.astimezone(dt.UTC)
+
+
 class InstalledProject:
     _repo: Repo
 
-    def __init__(self, project: Project) -> None:
+    def __init__(self, project: Project, exclude_newer: str | None = None) -> None:
         self._project = project
+        self._exclude_newer = exclude_newer
         self._cache_path = _get_project_cache_path(project)
         self._temp_dir = tempfile.TemporaryDirectory()
+
+        if exclude_newer is not None:
+            validate_exclude_newer(exclude_newer)
 
         self._clone_or_update()
         self._install_dependencies()
@@ -104,6 +133,61 @@ class InstalledProject:
             logger.error(f"Error cloning/updating repository: {e}")
             return
 
+        if self._exclude_newer is not None:
+            self._pin_to_timestamp()
+
+    def _pin_to_timestamp(self) -> None:
+        """Checkout the latest commit at or before the exclude-newer timestamp."""
+        assert self._exclude_newer is not None
+
+        cutoff = validate_exclude_newer(self._exclude_newer)
+        head_date = self._repo.head.commit.committed_datetime.astimezone(dt.UTC)
+
+        if head_date <= cutoff:
+            logger.debug(
+                f"'{self.name}': HEAD ({head_date.isoformat()}) is already "
+                f"at or before {self._exclude_newer}"
+            )
+            return
+
+        logger.info(
+            f"'{self.name}': HEAD ({head_date.isoformat()}) is newer than "
+            f"{self._exclude_newer}, searching for older commit"
+        )
+
+        # Deepen the shallow clone to find a commit before the cutoff
+        try:
+            self._repo.git.fetch("--deepen", "20")
+        except GitError:
+            logger.warning(
+                f"'{self.name}': failed to deepen clone, using HEAD as-is"
+            )
+            return
+
+        try:
+            commit_hash = self._repo.git.rev_list(
+                "HEAD", "--before", self._exclude_newer, "-1"
+            )
+        except GitError:
+            logger.warning(
+                f"'{self.name}': failed to find commit before "
+                f"{self._exclude_newer}, using HEAD as-is"
+            )
+            return
+
+        if not commit_hash.strip():
+            logger.warning(
+                f"'{self.name}': no commit found before "
+                f"{self._exclude_newer}, using HEAD as-is"
+            )
+            return
+
+        logger.info(
+            f"'{self.name}': checking out {commit_hash[:12]} "
+            f"(latest before {self._exclude_newer})"
+        )
+        self._repo.git.checkout(commit_hash)
+
     def _install_dependencies(self) -> None:
         # Create venv in temporary directory
         venv_cmd = ["uv", "venv", "--quiet", "--python", PYTHON_VERSION]
@@ -118,6 +202,8 @@ class InstalledProject:
 
             # Use absolute path to venv python for install commands
             install_placeholder = f"uv pip install --python {venv_python}"
+            if self._exclude_newer:
+                install_placeholder += f" --exclude-newer {self._exclude_newer}"
             install_cmd = self._project.install_cmd.format(install=install_placeholder)
 
             logger.debug(f"Executing: '{install_cmd}'")
@@ -131,6 +217,7 @@ class InstalledProject:
         elif self._project.deps:
             logger.info(f"Installing dependencies: {', '.join(self._project.deps)}")
 
+            exclude_newer_args = ["--exclude-newer", self._exclude_newer] if self._exclude_newer else []
             pip_cmd = [
                 "uv",
                 "pip",
@@ -138,6 +225,7 @@ class InstalledProject:
                 "--python",
                 str(venv_python),
                 "--link-mode=copy",
+                *exclude_newer_args,
                 *self._project.deps,
             ]
             logger.debug(f"Executing: {' '.join(pip_cmd)}")

--- a/src/ecosystem_analyzer/main.py
+++ b/src/ecosystem_analyzer/main.py
@@ -146,6 +146,13 @@ def run(ctx, project_name: str, commit: str, output: str, profile: str) -> None:
     type=click.Path(exists=True, dir_okay=False, readable=True),
     required=False,
 )
+@click.option(
+    "--exclude-newer",
+    help="ISO 8601 timestamp cutoff for reproducibility: pin git repos to the latest commit "
+    "at or before this time, and pass --exclude-newer to uv pip install",
+    type=str,
+    required=False,
+)
 @click.pass_context
 def analyze(
     ctx,
@@ -154,6 +161,7 @@ def analyze(
     output: str,
     profile: str,
     projects_flaky: str | None,
+    exclude_newer: str | None,
 ) -> None:
     """
     Analyze Python ecosystem projects with ty and collect diagnostics.
@@ -174,6 +182,7 @@ def analyze(
         profile=profile,
         flaky_runs=ctx.obj["flaky_runs"],
         flaky_projects=flaky_project_names,
+        exclude_newer=exclude_newer,
     )
     run_outputs = manager.run_for_commit(commit)
     manager.write_run_outputs(run_outputs, output)
@@ -228,6 +237,13 @@ def analyze(
     type=click.Path(exists=True, dir_okay=False, readable=True),
     required=False,
 )
+@click.option(
+    "--exclude-newer",
+    help="ISO 8601 timestamp cutoff for reproducibility: pin git repos to the latest commit "
+    "at or before this time, and pass --exclude-newer to uv pip install",
+    type=str,
+    required=False,
+)
 @click.pass_context
 def diff(
     ctx,
@@ -239,6 +255,7 @@ def diff(
     output_new: str,
     profile: str,
     projects_flaky: str | None,
+    exclude_newer: str | None,
 ) -> None:
     """
     Compare diagnostics between two commits.
@@ -263,6 +280,7 @@ def diff(
         profile=profile,
         flaky_runs=ctx.obj["flaky_runs"],
         flaky_projects=flaky_project_names,
+        exclude_newer=exclude_newer,
     )
 
     # Build old ty first — this overlaps with background project installation

--- a/src/ecosystem_analyzer/manager.py
+++ b/src/ecosystem_analyzer/manager.py
@@ -45,12 +45,14 @@ class Manager:
         profile: str = "dev",
         flaky_runs: int = 1,
         flaky_projects: set[str] | None = None,
+        exclude_newer: str | None = None,
     ) -> None:
         self._installed_projects = []
         self._active_projects = []
         self._ty = Ty(ty_repo, target_dir, profile=profile)
         self._flaky_runs = flaky_runs
         self._flaky_projects = flaky_projects or set()
+        self._exclude_newer = exclude_newer
 
         self._ecosystem_projects = _get_ecosystem_projects()
 
@@ -80,7 +82,7 @@ class Manager:
         def install_single_project(project_name: str) -> InstalledProject:
             logger.info(f"Processing project: {project_name}")
             project = self._ecosystem_projects[project_name]
-            return InstalledProject(project)
+            return InstalledProject(project, exclude_newer=self._exclude_newer)
 
         max_workers = min(len(self._project_names), 8)
 

--- a/tests/test_exclude_newer.py
+++ b/tests/test_exclude_newer.py
@@ -1,0 +1,163 @@
+import datetime as dt
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+from mypy_primer.model import Project
+
+from ecosystem_analyzer.installed_project import (
+    InstalledProject,
+    validate_exclude_newer,
+)
+
+
+def _make_project(**kwargs) -> Project:
+    """Create a minimal Project for testing."""
+    defaults: dict[str, Any] = {
+        "location": "https://github.com/test/repo",
+        "mypy_cmd": None,
+        "pyright_cmd": None,
+    }
+    return Project(**(defaults | kwargs))
+
+
+class TestValidateExcludeNewer:
+    """Tests for the --exclude-newer timestamp validation."""
+
+    def test_utc_z_suffix(self):
+        """The format produced by `date -u +%Y-%m-%dT%H:%M:%SZ`."""
+        result = validate_exclude_newer("2026-04-09T14:30:00Z")
+        assert result == dt.datetime(2026, 4, 9, 14, 30, 0, tzinfo=dt.UTC)
+
+    def test_utc_offset_zero(self):
+        result = validate_exclude_newer("2026-04-09T14:30:00+00:00")
+        assert result == dt.datetime(2026, 4, 9, 14, 30, 0, tzinfo=dt.UTC)
+
+    def test_non_utc_offset_is_converted(self):
+        result = validate_exclude_newer("2026-04-09T16:30:00+02:00")
+        assert result == dt.datetime(2026, 4, 9, 14, 30, 0, tzinfo=dt.UTC)
+
+    def test_with_fractional_seconds(self):
+        result = validate_exclude_newer("2026-04-09T14:30:00.123456Z")
+        assert result.year == 2026
+        assert result.microsecond == 123456
+
+    def test_rejects_naive_timestamp(self):
+        """Timestamps without timezone info are rejected."""
+        with pytest.raises(ValueError, match="missing timezone info"):
+            validate_exclude_newer("2026-04-09T14:30:00")
+
+    def test_rejects_date_only(self):
+        """A bare date without time/timezone is rejected."""
+        with pytest.raises(ValueError, match="missing timezone info"):
+            validate_exclude_newer("2026-04-09")
+
+    def test_rejects_garbage(self):
+        with pytest.raises(ValueError, match="Invalid --exclude-newer timestamp"):
+            validate_exclude_newer("not-a-timestamp")
+
+    def test_rejects_empty_string(self):
+        with pytest.raises(ValueError, match="Invalid --exclude-newer timestamp"):
+            validate_exclude_newer("")
+
+    def test_rejects_unix_timestamp(self):
+        with pytest.raises(ValueError, match="Invalid --exclude-newer timestamp"):
+            validate_exclude_newer("1712345678")
+
+
+class TestInstalledProjectExcludeNewer:
+    """Tests that InstalledProject validates --exclude-newer before doing work."""
+
+    @patch.object(InstalledProject, "_install_dependencies")
+    @patch.object(InstalledProject, "_clone_or_update")
+    def test_rejects_invalid_timestamp_before_cloning(self, mock_clone, mock_install):
+        """Invalid timestamps raise ValueError before any cloning or installing."""
+        with pytest.raises(ValueError, match="Invalid --exclude-newer timestamp"):
+            InstalledProject(_make_project(), exclude_newer="garbage")
+
+        mock_clone.assert_not_called()
+        mock_install.assert_not_called()
+
+    @patch.object(InstalledProject, "_install_dependencies")
+    @patch.object(InstalledProject, "_clone_or_update")
+    def test_rejects_naive_timestamp_before_cloning(self, mock_clone, mock_install):
+        with pytest.raises(ValueError, match="missing timezone info"):
+            InstalledProject(_make_project(), exclude_newer="2026-04-09T14:30:00")
+
+        mock_clone.assert_not_called()
+        mock_install.assert_not_called()
+
+    @patch.object(InstalledProject, "_install_dependencies")
+    @patch.object(InstalledProject, "_clone_or_update")
+    def test_accepts_valid_timestamp(self, mock_clone, mock_install):
+        project = InstalledProject(
+            _make_project(), exclude_newer="2026-04-09T14:30:00Z"
+        )
+        assert project._exclude_newer == "2026-04-09T14:30:00Z"
+        mock_clone.assert_called_once()
+        mock_install.assert_called_once()
+
+    @patch.object(InstalledProject, "_install_dependencies")
+    @patch.object(InstalledProject, "_clone_or_update")
+    def test_none_exclude_newer_skips_validation(self, mock_clone, mock_install):
+        project = InstalledProject(_make_project(), exclude_newer=None)
+        assert project._exclude_newer is None
+        mock_clone.assert_called_once()
+        mock_install.assert_called_once()
+
+
+class TestInstallDependenciesExcludeNewer:
+    """Tests that --exclude-newer is correctly passed to uv pip install commands."""
+
+    @patch("ecosystem_analyzer.installed_project.subprocess.run")
+    @patch.object(InstalledProject, "_clone_or_update")
+    def test_deps_include_exclude_newer(self, _mock_clone, mock_run):
+        """When deps are specified, --exclude-newer appears in the pip install args."""
+        InstalledProject(
+            _make_project(deps=["requests", "six"]),
+            exclude_newer="2026-04-09T14:30:00Z",
+        )
+
+        # First call is `uv venv`, second is `uv pip install`
+        assert mock_run.call_count == 2
+        pip_call_args = mock_run.call_args_list[1]
+        cmd = pip_call_args.args[0]
+        assert "--exclude-newer" in cmd
+        idx = cmd.index("--exclude-newer")
+        assert cmd[idx + 1] == "2026-04-09T14:30:00Z"
+
+    @patch("ecosystem_analyzer.installed_project.subprocess.run")
+    @patch.object(InstalledProject, "_clone_or_update")
+    def test_deps_omit_exclude_newer_when_none(self, _mock_clone, mock_run):
+        """When exclude_newer is None, --exclude-newer does not appear."""
+        InstalledProject(_make_project(deps=["requests"]))
+
+        assert mock_run.call_count == 2
+        pip_call_args = mock_run.call_args_list[1]
+        cmd = pip_call_args.args[0]
+        assert "--exclude-newer" not in cmd
+
+    @patch("ecosystem_analyzer.installed_project.subprocess.run")
+    @patch.object(InstalledProject, "_clone_or_update")
+    def test_install_cmd_includes_exclude_newer(self, _mock_clone, mock_run):
+        """Custom install_cmd templates get --exclude-newer in the {install} placeholder."""
+        InstalledProject(
+            _make_project(install_cmd="{install} -e ."),
+            exclude_newer="2026-04-09T14:30:00Z",
+        )
+
+        assert mock_run.call_count == 2
+        install_call_args = mock_run.call_args_list[1]
+        cmd_str = install_call_args.args[0]
+        assert "--exclude-newer 2026-04-09T14:30:00Z" in cmd_str
+
+    @patch("ecosystem_analyzer.installed_project.subprocess.run")
+    @patch.object(InstalledProject, "_clone_or_update")
+    def test_install_cmd_omits_exclude_newer_when_none(self, _mock_clone, mock_run):
+        """Custom install_cmd without exclude_newer doesn't include the flag."""
+        InstalledProject(_make_project(install_cmd="{install} -e ."))
+
+        assert mock_run.call_count == 2
+        install_call_args = mock_run.call_args_list[1]
+        cmd_str = install_call_args.args[0]
+        assert "--exclude-newer" not in cmd_str


### PR DESCRIPTION
The `--exclude-newer` flag ensures that ecosystem-analyzer doesn't use a commit newer than a given timestamp when checking out ecosystem projects, and doesn't install any dependencies newer than that timestamp either. We should be able to use it in https://github.com/astral-sh/ruff/pull/24503 to address this review comment: https://github.com/astral-sh/ruff/pull/24503#issuecomment-4213713073. (We can have a preliminary timestamp job that records a timestamp which is then passed to the two parallel workers using this `--exclude-newer` flag.)