### PR TITLE
Add flags to enable sharding projects between workers

### DIFF
--- a/src/ecosystem_analyzer/main.py
+++ b/src/ecosystem_analyzer/main.py
@@ -24,6 +24,29 @@ def setup_logging(verbose: bool = False) -> None:
     )
 
 
+def shard_project_lists(
+    project_names_old: list[str],
+    project_names_new: list[str],
+    shard: int,
+    num_shards: int,
+) -> tuple[list[str], list[str]]:
+    """Filter project lists to only include projects belonging to this shard.
+
+    Sharding is based on the sorted union of both lists, so each project
+    consistently lands in the same shard for both old and new.
+    """
+    all_names_sorted = sorted(set(project_names_old + project_names_new))
+    shard_set = {
+        name
+        for i, name in enumerate(all_names_sorted)
+        if i % num_shards == shard
+    }
+    return (
+        [n for n in project_names_old if n in shard_set],
+        [n for n in project_names_new if n in shard_set],
+    )
+
+
 @click.group(context_settings={"help_option_names": ["-h", "--help"]})
 @click.option(
     "--repository",
@@ -244,6 +267,18 @@ def analyze(
     type=str,
     required=False,
 )
+@click.option(
+    "--shard",
+    help="Shard index (0-based) for splitting the project list across workers",
+    type=int,
+    required=False,
+)
+@click.option(
+    "--num-shards",
+    help="Total number of shards for splitting the project list",
+    type=int,
+    required=False,
+)
 @click.pass_context
 def diff(
     ctx,
@@ -256,6 +291,8 @@ def diff(
     profile: str,
     projects_flaky: str | None,
     exclude_newer: str | None,
+    shard: int | None,
+    num_shards: int | None,
 ) -> None:
     """
     Compare diagnostics between two commits.
@@ -264,11 +301,31 @@ def diff(
         click.echo("Error: --repository is required for this command", err=True)
         ctx.exit(1)
 
+    if (shard is None) != (num_shards is None):
+        raise click.UsageError("--shard and --num-shards must be used together")
+
+    if shard is not None and num_shards is not None:
+        if shard < 0 or shard >= num_shards:
+            raise click.UsageError(
+                f"--shard must be in range [0, {num_shards})"
+            )
+
     project_names_old = Path(projects_old).read_text().splitlines()
     project_names_new = Path(projects_new).read_text().splitlines()
     flaky_project_names = (
         set(Path(projects_flaky).read_text().splitlines()) if projects_flaky else None
     )
+
+    if num_shards is not None:
+        assert shard is not None
+        project_names_old, project_names_new = shard_project_lists(
+            project_names_old, project_names_new, shard, num_shards
+        )
+        logger.info(
+            f"Shard {shard}/{num_shards}: "
+            f"{len(project_names_old)} old projects, "
+            f"{len(project_names_new)} new projects"
+        )
 
     # Create union of both project lists for installation
     all_project_names = list(set(project_names_old + project_names_new))

--- a/src/ecosystem_analyzer/main.py
+++ b/src/ecosystem_analyzer/main.py
@@ -279,6 +279,18 @@ def analyze(
     type=int,
     required=False,
 )
+@click.option(
+    "--ty-binary-old",
+    help="Path to a pre-built ty binary for the old commit (skips building)",
+    type=click.Path(exists=True, dir_okay=False, readable=True, path_type=Path),
+    required=False,
+)
+@click.option(
+    "--ty-binary-new",
+    help="Path to a pre-built ty binary for the new commit (skips building)",
+    type=click.Path(exists=True, dir_okay=False, readable=True, path_type=Path),
+    required=False,
+)
 @click.pass_context
 def diff(
     ctx,
@@ -293,12 +305,19 @@ def diff(
     exclude_newer: str | None,
     shard: int | None,
     num_shards: int | None,
+    ty_binary_old: Path | None,
+    ty_binary_new: Path | None,
 ) -> None:
     """
     Compare diagnostics between two commits.
     """
-    if ctx.obj["repository"] is None:
-        click.echo("Error: --repository is required for this command", err=True)
+    using_prebuilt = ty_binary_old is not None and ty_binary_new is not None
+    if ctx.obj["repository"] is None and not using_prebuilt:
+        click.echo(
+            "Error: --repository is required unless both --ty-binary-old and"
+            " --ty-binary-new are provided",
+            err=True,
+        )
         ctx.exit(1)
 
     if (shard is None) != (num_shards is None):
@@ -340,16 +359,23 @@ def diff(
         exclude_newer=exclude_newer,
     )
 
-    # Build old ty first — this overlaps with background project installation
-    manager.build(old)
+    # Build (or use pre-built) old ty — building overlaps with background
+    # project installation
+    if ty_binary_old is not None:
+        manager.use_prebuilt(ty_binary_old, old)
+    else:
+        manager.build(old)
 
     # Run for old commit with old projects
     manager.activate(project_names_old)
     run_outputs_old = manager.run_active_projects()
     manager.write_run_outputs(run_outputs_old, output_old)
 
-    # Run for new commit with new projects (incremental build, near-instant)
-    manager.build(new)
+    # Build (or use pre-built) new ty — incremental build is near-instant
+    if ty_binary_new is not None:
+        manager.use_prebuilt(ty_binary_new, new)
+    else:
+        manager.build(new)
     manager.activate(project_names_new)
     run_outputs_new = manager.run_active_projects()
     manager.write_run_outputs(run_outputs_new, output_new)

--- a/src/ecosystem_analyzer/manager.py
+++ b/src/ecosystem_analyzer/manager.py
@@ -39,7 +39,7 @@ class Manager:
     def __init__(
         self,
         *,
-        ty_repo: Repo,
+        ty_repo: Repo | None = None,
         target_dir: Path | None,
         project_names: list[str],
         profile: str = "dev",
@@ -149,6 +149,10 @@ class Manager:
     def build(self, commit: str | Commit) -> None:
         """Build ty for a commit. Can be called while projects are still installing."""
         self._ty.compile_for_commit(commit)
+
+    def use_prebuilt(self, binary_path: Path, commit_sha: str) -> None:
+        """Use a pre-built ty binary instead of building from source."""
+        self._ty.use_prebuilt(binary_path, commit_sha)
 
     def run_for_commit(self, commit: str | Commit) -> list[RunOutput]:
         """Build ty for a commit and run it on active projects.

--- a/src/ecosystem_analyzer/ty.py
+++ b/src/ecosystem_analyzer/ty.py
@@ -24,12 +24,17 @@ def _normalize_stderr(stderr: str) -> str | None:
 
 class Ty:
     def __init__(
-        self, repository: Repo, target_dir: Path | None, profile: str = "dev"
+        self,
+        repository: Repo | None = None,
+        target_dir: Path | None = None,
+        profile: str = "dev",
     ) -> None:
-        self.repository: Repo = repository
-        self.working_dir: Path = Path(self.repository.working_dir)
-        self.cargo_target_dir: Path = target_dir or self.working_dir / "target"
+        self.repository: Repo | None = repository
+        if repository is not None:
+            self.working_dir: Path = Path(repository.working_dir)
+            self.cargo_target_dir: Path = target_dir or self.working_dir / "target"
         self.profile: str = profile
+        self._commit_override: str | None = None
 
     def compile_for_commit(self, commit: str | Commit):
         # Checkout the commit
@@ -57,6 +62,22 @@ class Ty:
         # For other profiles, the directory name matches the profile name
         target_dir = "debug" if self.profile == "dev" else self.profile
         self.executable = self.cargo_target_dir / target_dir / "ty"
+        self._commit_override = None
+
+    def use_prebuilt(self, binary_path: Path, commit_sha: str) -> None:
+        """Use a pre-built ty binary instead of building from source."""
+        self.executable = binary_path.resolve()
+        self._commit_override = commit_sha
+
+    @property
+    def commit_sha(self) -> str:
+        if self._commit_override is not None:
+            return self._commit_override
+        if self.repository is None:
+            raise RuntimeError(
+                "No commit SHA available: no repository and no prebuilt override set"
+            )
+        return self.repository.head.commit.hexsha
 
     def run_on_project(self, project: InstalledProject) -> RunOutput:
         logger.info(f"Running ty on project '{project.name}'")
@@ -135,7 +156,7 @@ class Ty:
             {
                 "project": project.name,
                 "project_location": project.location,
-                "ty_commit": self.repository.head.commit.hexsha,
+                "ty_commit": self.commit_sha,
                 "diagnostics": diagnostics,
                 "time_s": execution_time,
                 "return_code": return_code,
@@ -205,7 +226,7 @@ class Ty:
             {
                 "project": project.name,
                 "project_location": project.location,
-                "ty_commit": self.repository.head.commit.hexsha,
+                "ty_commit": self.commit_sha,
                 "diagnostics": stable,
                 "flaky_runs": n,
                 "time_s": median_time,

--- a/tests/test_sharding.py
+++ b/tests/test_sharding.py
@@ -1,0 +1,128 @@
+from click.testing import CliRunner
+from git import Repo
+
+from ecosystem_analyzer.main import cli, shard_project_lists
+
+
+def test_two_shards_partition_all_projects():
+    """All shards together cover the full project list with no overlaps."""
+    projects = ["alpha", "bravo", "charlie", "delta", "echo"]
+    shard_0, _ = shard_project_lists(projects, projects, shard=0, num_shards=2)
+    shard_1, _ = shard_project_lists(projects, projects, shard=1, num_shards=2)
+    assert sorted(shard_0 + shard_1) == sorted(projects)
+    assert not set(shard_0) & set(shard_1)
+
+
+def test_three_shards_partition_all_projects():
+    """Works correctly with an uneven split across three shards."""
+    projects = ["a", "b", "c", "d", "e", "f", "g"]
+    all_sharded: list[str] = []
+    for s in range(3):
+        old, _ = shard_project_lists(projects, projects, shard=s, num_shards=3)
+        all_sharded.extend(old)
+    assert sorted(all_sharded) == sorted(projects)
+
+
+def test_round_robin_assignment():
+    """Projects are assigned round-robin by index in sorted order."""
+    projects = ["a", "b", "c", "d", "e", "f"]
+    # Sorted: a(0), b(1), c(2), d(3), e(4), f(5)
+    # num_shards=3: shard 0 gets indices 0,3 → a,d
+    #               shard 1 gets indices 1,4 → b,e
+    #               shard 2 gets indices 2,5 → c,f
+    s0, _ = shard_project_lists(projects, projects, shard=0, num_shards=3)
+    s1, _ = shard_project_lists(projects, projects, shard=1, num_shards=3)
+    s2, _ = shard_project_lists(projects, projects, shard=2, num_shards=3)
+    assert s0 == ["a", "d"]
+    assert s1 == ["b", "e"]
+    assert s2 == ["c", "f"]
+
+
+def test_consistent_across_old_and_new():
+    """A project in both lists always lands in the same shard."""
+    old = ["alpha", "bravo", "charlie"]
+    new = ["bravo", "charlie", "delta"]
+    old_s0, new_s0 = shard_project_lists(old, new, shard=0, num_shards=2)
+    old_s1, new_s1 = shard_project_lists(old, new, shard=1, num_shards=2)
+    # bravo and charlie appear in both lists; verify they land in the
+    # same shard on each side
+    for project in ["bravo", "charlie"]:
+        in_old_0 = project in old_s0
+        in_new_0 = project in new_s0
+        assert in_old_0 == in_new_0, f"{project} inconsistent across old/new"
+
+
+def test_project_added_in_new():
+    """A project only in the new list still gets sharded consistently."""
+    old = ["a", "c"]
+    new = ["a", "b", "c"]
+    # Union sorted: a(0), b(1), c(2); shard 0 with num_shards=2 → indices 0,2 → a,c
+    old_s0, new_s0 = shard_project_lists(old, new, shard=0, num_shards=2)
+    assert old_s0 == ["a", "c"]
+    assert new_s0 == ["a", "c"]
+    old_s1, new_s1 = shard_project_lists(old, new, shard=1, num_shards=2)
+    assert old_s1 == []
+    assert new_s1 == ["b"]
+
+
+def test_preserves_input_order():
+    """Output order matches the input list order, not sorted order."""
+    projects = ["delta", "alpha", "charlie", "bravo"]
+    result, _ = shard_project_lists(projects, projects, shard=0, num_shards=2)
+    # Sorted union: alpha(0), bravo(1), charlie(2), delta(3)
+    # Shard 0 → indices 0,2 → {alpha, charlie}
+    # Input order of those: alpha then charlie (positions 1 and 2 in input)
+    assert result == ["alpha", "charlie"]
+
+
+def test_single_shard_returns_everything():
+    """With num_shards=1, the sole shard gets all projects."""
+    projects = ["x", "y", "z"]
+    old, new = shard_project_lists(projects, projects, shard=0, num_shards=1)
+    assert old == projects
+    assert new == projects
+
+
+def test_more_shards_than_projects():
+    """Shards beyond the project count are empty."""
+    projects = ["a", "b"]
+    s0, _ = shard_project_lists(projects, projects, shard=0, num_shards=5)
+    s1, _ = shard_project_lists(projects, projects, shard=1, num_shards=5)
+    s2, _ = shard_project_lists(projects, projects, shard=2, num_shards=5)
+    assert s0 == ["a"]
+    assert s1 == ["b"]
+    assert s2 == []
+
+
+def _invoke_diff(tmp_path, extra_args):
+    """Invoke the `diff` subcommand with minimal valid required args."""
+    Repo.init(tmp_path)
+    projects = tmp_path / "projects.txt"
+    projects.write_text("a\nb\n")
+    runner = CliRunner()
+    return runner.invoke(
+        cli,
+        [
+            "--repository", str(tmp_path),
+            "diff",
+            "--projects-old", str(projects),
+            "--projects-new", str(projects),
+            "--old", "HEAD",
+            "--new", "HEAD",
+            *extra_args,
+        ],
+    )
+
+
+def test_shard_without_num_shards_is_error(tmp_path):
+    """Providing --shard alone is an error."""
+    result = _invoke_diff(tmp_path, ["--shard", "0"])
+    assert result.exit_code != 0
+    assert "--shard and --num-shards must be used together" in result.output
+
+
+def test_num_shards_without_shard_is_error(tmp_path):
+    """Providing --num-shards alone is an error."""
+    result = _invoke_diff(tmp_path, ["--num-shards", "2"])
+    assert result.exit_code != 0
+    assert "--shard and --num-shards must be used together" in result.output

--- a/tests/test_sharding.py
+++ b/tests/test_sharding.py
@@ -1,7 +1,11 @@
+from pathlib import Path
+
+import pytest
 from click.testing import CliRunner
 from git import Repo
 
 from ecosystem_analyzer.main import cli, shard_project_lists
+from ecosystem_analyzer.ty import Ty
 
 
 def test_two_shards_partition_all_projects():
@@ -126,3 +130,59 @@ def test_num_shards_without_shard_is_error(tmp_path):
     result = _invoke_diff(tmp_path, ["--num-shards", "2"])
     assert result.exit_code != 0
     assert "--shard and --num-shards must be used together" in result.output
+
+
+# -- Prebuilt binary tests --
+
+
+def test_use_prebuilt_sets_executable_and_commit():
+    """use_prebuilt sets the executable path and overrides the commit SHA."""
+    ty = Ty()
+    binary = Path("/tmp/ty-prebuilt")
+    ty.use_prebuilt(binary, "abc123")
+    assert ty.executable == binary.resolve()
+    assert ty.commit_sha == "abc123"
+
+
+def test_use_prebuilt_overrides_previous_commit():
+    """Calling use_prebuilt twice updates the commit SHA."""
+    ty = Ty()
+    ty.use_prebuilt(Path("/tmp/ty-old"), "aaa")
+    ty.use_prebuilt(Path("/tmp/ty-new"), "bbb")
+    assert ty.commit_sha == "bbb"
+
+
+def test_commit_sha_without_repo_or_override_raises():
+    """Accessing commit_sha with no repo and no override is an error."""
+    ty = Ty()
+    with pytest.raises(RuntimeError, match="No commit SHA available"):
+        _ = ty.commit_sha
+
+
+def test_commit_sha_falls_back_to_repo(tmp_path):
+    """Without an override, commit_sha reads from the repository HEAD."""
+    repo = Repo.init(tmp_path)
+    (tmp_path / "f.txt").write_text("x")
+    repo.index.add(["f.txt"])
+    repo.index.commit("init")
+    ty = Ty(repository=repo)
+    assert ty.commit_sha == repo.head.commit.hexsha
+
+
+def test_diff_without_repository_requires_prebuilt_binaries(tmp_path):
+    """Omitting --repository is an error unless both --ty-binary-* are given."""
+    projects = tmp_path / "projects.txt"
+    projects.write_text("a\nb\n")
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "diff",
+            "--projects-old", str(projects),
+            "--projects-new", str(projects),
+            "--old", "abc",
+            "--new", "def",
+        ],
+    )
+    assert result.exit_code != 0
+    assert "--repository is required" in result.output


### PR DESCRIPTION
We've observed that the timing reports may have become more unstable following https://github.com/astral-sh/ruff/pull/24503, so this PR adds `--num-shards` and `--shard` flags to enable easily splitting a projects list between ecosystem-analyzer workers. This could also be done using a shell script in Ruff's ecosystem-analyzer workflow, but it was getting more complicated than I'd like for an embedded shell script in a `.yaml` workflow file, so this seemed cleaner. It's also basically the way that mypy_primer does sharding upstream.