### PR TITLE
Distribute projects across shards based on expected timings in CI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "A tool for analyzing Python projects with ty"
 dependencies = [
     "gitpython==3.1.46",
-    "mypy-primer @ git+https://github.com/hauntsaninja/mypy_primer@850d65d9da947ef9e02498b6f07598e7c8401641",
+    "mypy-primer @ git+https://github.com/hauntsaninja/mypy_primer@00ded1e9df38b86bf4825457e7fa17d89c215d05",
     "click==8.3.2",
     "jinja2==3.1.6",
 ]

--- a/src/ecosystem_analyzer/main.py
+++ b/src/ecosystem_analyzer/main.py
@@ -4,12 +4,13 @@ import sys
 from pathlib import Path
 
 import click
+from mypy_primer.model import Project
 
 from .diagnostic import DiagnosticsParser
 from .diff import DiagnosticDiff
 from .ecosystem_report import generate
 from .git import get_latest_ty_commits, resolve_ty_repo
-from .manager import Manager
+from .manager import Manager, get_ecosystem_projects
 
 logger = logging.getLogger(__name__)
 
@@ -29,19 +30,43 @@ def shard_project_lists(
     project_names_new: list[str],
     shard: int,
     num_shards: int,
+    ecosystem_projects: dict[str, Project],
+    flaky_projects: set[str] | None = None,
+    flaky_runs: int = 1,
 ) -> tuple[list[str], list[str]]:
     """Filter project lists to only include projects belonging to this shard.
 
-    Sharding is based on the sorted union of both lists, so each project
-    consistently lands in the same shard for both old and new.
+    Uses greedy bin-packing based on mypy_primer cost estimates so that
+    expensive projects are spread across shards rather than clustered.
     """
-    all_names_sorted = sorted(set(project_names_old + project_names_new))
-    shard_set = {
-        name for i, name in enumerate(all_names_sorted) if i % num_shards == shard
-    }
+    all_names = sorted(set(project_names_old + project_names_new))
+
+    # Sort by cost descending (with name as tiebreaker for determinism),
+    # then greedily assign each project to the lightest shard.
+    costs: dict[str, int] = {}
+    for name in all_names:
+        project = ecosystem_projects.get(name)
+        if project is not None:
+            cost = project.cost_for_type_checker("ty")
+        else:
+            cost = 5
+        if flaky_projects is not None and name in flaky_projects:
+            cost *= flaky_runs
+        costs[name] = cost
+
+    sorted_by_cost = sorted(all_names, key=lambda n: (-costs[n], n))
+
+    shard_costs = [0] * num_shards
+    shard_sets: list[set[str]] = [set() for _ in range(num_shards)]
+    for name in sorted_by_cost:
+        min_shard = min(range(num_shards), key=lambda i: shard_costs[i])
+        shard_costs[min_shard] += costs[name]
+        shard_sets[min_shard].add(name)
+
+    target = shard_sets[shard]
     return (
-        [n for n in project_names_old if n in shard_set],
-        [n for n in project_names_new if n in shard_set],
+        [n for n in project_names_old if n in target],
+        [n for n in project_names_new if n in target],
     )
 
 
@@ -334,10 +359,19 @@ def diff(
         set(Path(projects_flaky).read_text().splitlines()) if projects_flaky else None
     )
 
+    ecosystem_projects: dict[str, Project] | None = None
+
     if num_shards is not None:
         assert shard is not None
+        ecosystem_projects = get_ecosystem_projects()
         project_names_old, project_names_new = shard_project_lists(
-            project_names_old, project_names_new, shard, num_shards
+            project_names_old,
+            project_names_new,
+            shard,
+            num_shards,
+            ecosystem_projects,
+            flaky_projects=flaky_project_names,
+            flaky_runs=ctx.obj["flaky_runs"],
         )
         logger.info(
             f"Shard {shard}/{num_shards}: "
@@ -356,6 +390,7 @@ def diff(
         flaky_runs=ctx.obj["flaky_runs"],
         flaky_projects=flaky_project_names,
         exclude_newer=exclude_newer,
+        ecosystem_projects=ecosystem_projects,
     )
 
     # Build (or use pre-built) old ty — building overlaps with background

--- a/src/ecosystem_analyzer/manager.py
+++ b/src/ecosystem_analyzer/manager.py
@@ -15,7 +15,7 @@ from .ty import Ty
 logger = logging.getLogger(__name__)
 
 
-def _get_ecosystem_projects() -> dict[str, Project]:
+def get_ecosystem_projects() -> dict[str, Project]:
     projects: dict[str, Project] = {}
     for project in get_projects():
         project_name = (
@@ -46,6 +46,7 @@ class Manager:
         flaky_runs: int = 1,
         flaky_projects: set[str] | None = None,
         exclude_newer: str | None = None,
+        ecosystem_projects: dict[str, Project] | None = None,
     ) -> None:
         self._installed_projects = []
         self._active_projects = []
@@ -54,7 +55,11 @@ class Manager:
         self._flaky_projects = flaky_projects or set()
         self._exclude_newer = exclude_newer
 
-        self._ecosystem_projects = _get_ecosystem_projects()
+        self._ecosystem_projects = (
+            ecosystem_projects
+            if ecosystem_projects is not None
+            else get_ecosystem_projects()
+        )
 
         unavailable_projects = set(project_names) - set(self._ecosystem_projects.keys())
         if unavailable_projects:

--- a/tests/test_sharding.py
+++ b/tests/test_sharding.py
@@ -3,16 +3,31 @@ from pathlib import Path
 import pytest
 from click.testing import CliRunner
 from git import Repo
+from mypy_primer.model import Project
 
 from ecosystem_analyzer.main import cli, shard_project_lists
 from ecosystem_analyzer.ty import Ty
 
 
+def _projects(*costs: tuple[str, int]) -> dict[str, Project]:
+    """Build a minimal ecosystem_projects dict from (name, ty_cost) pairs."""
+    return {
+        name: Project(
+            location=name, mypy_cmd="mypy", pyright_cmd="pyright", cost={"ty": c}
+        )
+        for name, c in costs
+    }
+
+
 def test_two_shards_partition_all_projects():
     """All shards together cover the full project list with no overlaps."""
     projects = ["alpha", "bravo", "charlie", "delta", "echo"]
-    shard_0, _ = shard_project_lists(projects, projects, shard=0, num_shards=2)
-    shard_1, _ = shard_project_lists(projects, projects, shard=1, num_shards=2)
+    shard_0, _ = shard_project_lists(
+        projects, projects, shard=0, num_shards=2, ecosystem_projects={}
+    )
+    shard_1, _ = shard_project_lists(
+        projects, projects, shard=1, num_shards=2, ecosystem_projects={}
+    )
     assert sorted(shard_0 + shard_1) == sorted(projects)
     assert not set(shard_0) & set(shard_1)
 
@@ -22,33 +37,54 @@ def test_three_shards_partition_all_projects():
     projects = ["a", "b", "c", "d", "e", "f", "g"]
     all_sharded: list[str] = []
     for s in range(3):
-        old, _ = shard_project_lists(projects, projects, shard=s, num_shards=3)
+        old, _ = shard_project_lists(
+            projects, projects, shard=s, num_shards=3, ecosystem_projects={}
+        )
         all_sharded.extend(old)
     assert sorted(all_sharded) == sorted(projects)
 
 
-def test_round_robin_assignment():
-    """Projects are assigned round-robin by index in sorted order."""
-    projects = ["a", "b", "c", "d", "e", "f"]
-    # Sorted: a(0), b(1), c(2), d(3), e(4), f(5)
-    # num_shards=3: shard 0 gets indices 0,3 → a,d
-    #               shard 1 gets indices 1,4 → b,e
-    #               shard 2 gets indices 2,5 → c,f
-    s0, _ = shard_project_lists(projects, projects, shard=0, num_shards=3)
-    s1, _ = shard_project_lists(projects, projects, shard=1, num_shards=3)
-    s2, _ = shard_project_lists(projects, projects, shard=2, num_shards=3)
+def test_bin_packing_spreads_expensive_projects():
+    """Expensive projects are spread across shards, not clustered."""
+    ep = _projects(("heavy_a", 100), ("heavy_b", 100), ("light_c", 1), ("light_d", 1))
+    projects = ["heavy_a", "heavy_b", "light_c", "light_d"]
+
+    s0, _ = shard_project_lists(
+        projects, projects, shard=0, num_shards=2, ecosystem_projects=ep
+    )
+    s1, _ = shard_project_lists(
+        projects, projects, shard=1, num_shards=2, ecosystem_projects=ep
+    )
+
+    assert s0 == ["heavy_a", "light_c"]
+    assert s1 == ["heavy_b", "light_d"]
+
+
+def test_bin_packing_deterministic_assignment():
+    """Verify the exact greedy assignment with known costs."""
+    ep = _projects(("a", 10), ("b", 7), ("c", 5), ("d", 3), ("e", 1))
+    projects = ["a", "b", "c", "d", "e"]
+
+    # Descending by (cost, name): a(10), b(7), c(5), d(3), e(1)
+    # Shard 0 gets: a(10), then d(3) → total 13
+    # Shard 1 gets: b(7), then c(5), then e(1) → total 13
+    s0, _ = shard_project_lists(
+        projects, projects, shard=0, num_shards=2, ecosystem_projects=ep
+    )
+    s1, _ = shard_project_lists(
+        projects, projects, shard=1, num_shards=2, ecosystem_projects=ep
+    )
     assert s0 == ["a", "d"]
-    assert s1 == ["b", "e"]
-    assert s2 == ["c", "f"]
+    assert s1 == ["b", "c", "e"]
 
 
 def test_consistent_across_old_and_new():
     """A project in both lists always lands in the same shard."""
     old = ["alpha", "bravo", "charlie"]
     new = ["bravo", "charlie", "delta"]
-    old_s0, new_s0 = shard_project_lists(old, new, shard=0, num_shards=2)
-    # bravo and charlie appear in both lists; verify they land in the
-    # same shard on each side
+    old_s0, new_s0 = shard_project_lists(
+        old, new, shard=0, num_shards=2, ecosystem_projects={}
+    )
     for project in ["bravo", "charlie"]:
         in_old_0 = project in old_s0
         in_new_0 = project in new_s0
@@ -59,11 +95,16 @@ def test_project_added_in_new():
     """A project only in the new list still gets sharded consistently."""
     old = ["a", "c"]
     new = ["a", "b", "c"]
-    # Union sorted: a(0), b(1), c(2); shard 0 with num_shards=2 → indices 0,2 → a,c
-    old_s0, new_s0 = shard_project_lists(old, new, shard=0, num_shards=2)
+    old_s0, new_s0 = shard_project_lists(
+        old, new, shard=0, num_shards=2, ecosystem_projects={}
+    )
+    old_s1, new_s1 = shard_project_lists(
+        old, new, shard=1, num_shards=2, ecosystem_projects={}
+    )
+    # All default cost 5; descending-by-cost then name: a, b, c
+    # Greedy: a→shard0, b→shard1, c→shard0
     assert old_s0 == ["a", "c"]
     assert new_s0 == ["a", "c"]
-    old_s1, new_s1 = shard_project_lists(old, new, shard=1, num_shards=2)
     assert old_s1 == []
     assert new_s1 == ["b"]
 
@@ -71,17 +112,19 @@ def test_project_added_in_new():
 def test_preserves_input_order():
     """Output order matches the input list order, not sorted order."""
     projects = ["delta", "alpha", "charlie", "bravo"]
-    result, _ = shard_project_lists(projects, projects, shard=0, num_shards=2)
-    # Sorted union: alpha(0), bravo(1), charlie(2), delta(3)
-    # Shard 0 → indices 0,2 → {alpha, charlie}
-    # Input order of those: alpha then charlie (positions 1 and 2 in input)
-    assert result == ["alpha", "charlie"]
+    result, _ = shard_project_lists(
+        projects, projects, shard=0, num_shards=2, ecosystem_projects={}
+    )
+    input_indices = [projects.index(p) for p in result]
+    assert input_indices == sorted(input_indices)
 
 
 def test_single_shard_returns_everything():
     """With num_shards=1, the sole shard gets all projects."""
     projects = ["x", "y", "z"]
-    old, new = shard_project_lists(projects, projects, shard=0, num_shards=1)
+    old, new = shard_project_lists(
+        projects, projects, shard=0, num_shards=1, ecosystem_projects={}
+    )
     assert old == projects
     assert new == projects
 
@@ -89,12 +132,75 @@ def test_single_shard_returns_everything():
 def test_more_shards_than_projects():
     """Shards beyond the project count are empty."""
     projects = ["a", "b"]
-    s0, _ = shard_project_lists(projects, projects, shard=0, num_shards=5)
-    s1, _ = shard_project_lists(projects, projects, shard=1, num_shards=5)
-    s2, _ = shard_project_lists(projects, projects, shard=2, num_shards=5)
-    assert s0 == ["a"]
-    assert s1 == ["b"]
-    assert s2 == []
+    all_sharded: list[str] = []
+    for s in range(5):
+        shard_result, _ = shard_project_lists(
+            projects, projects, shard=s, num_shards=5, ecosystem_projects={}
+        )
+        all_sharded.extend(shard_result)
+    assert sorted(all_sharded) == sorted(projects)
+
+    for s in range(2, 5):
+        shard_result, _ = shard_project_lists(
+            projects, projects, shard=s, num_shards=5, ecosystem_projects={}
+        )
+        assert shard_result == [], f"shard {s} should be empty"
+
+
+def test_unknown_projects_get_default_cost():
+    """Projects not in ecosystem_projects use the default cost."""
+    ep = _projects(("known", 100))
+    projects = ["known", "unknown_a", "unknown_b"]
+
+    s0, _ = shard_project_lists(
+        projects, projects, shard=0, num_shards=2, ecosystem_projects=ep
+    )
+    s1, _ = shard_project_lists(
+        projects, projects, shard=1, num_shards=2, ecosystem_projects=ep
+    )
+
+    assert "known" in s0 or "known" in s1
+    assert sorted(s0 + s1) == sorted(projects)
+
+
+def test_flaky_projects_cost_multiplied_by_flaky_runs():
+    """Flaky projects have their cost multiplied by flaky_runs."""
+    ep = _projects(("stable_big", 20), ("stable_small", 5), ("flaky", 10))
+    projects = ["stable_big", "stable_small", "flaky"]
+
+    # Without flaky multiplier: costs are 20, 5, 10.
+    # Greedy: stable_big(20)→s0, flaky(10)→s1, stable_small(5)→s1
+    s0, _ = shard_project_lists(
+        projects, projects, shard=0, num_shards=2, ecosystem_projects=ep
+    )
+    s1, _ = shard_project_lists(
+        projects, projects, shard=1, num_shards=2, ecosystem_projects=ep
+    )
+    assert s0 == ["stable_big"]
+    assert s1 == ["stable_small", "flaky"]
+
+    # With flaky_runs=3: flaky costs 30, stable_big 20, stable_small 5.
+    # Greedy: flaky(30)→s0, stable_big(20)→s1, stable_small(5)→s1
+    s0, _ = shard_project_lists(
+        projects,
+        projects,
+        shard=0,
+        num_shards=2,
+        ecosystem_projects=ep,
+        flaky_projects={"flaky"},
+        flaky_runs=3,
+    )
+    s1, _ = shard_project_lists(
+        projects,
+        projects,
+        shard=1,
+        num_shards=2,
+        ecosystem_projects=ep,
+        flaky_projects={"flaky"},
+        flaky_runs=3,
+    )
+    assert s0 == ["flaky"]
+    assert s1 == ["stable_big", "stable_small"]
 
 
 def _invoke_diff(tmp_path, extra_args):

--- a/uv.lock
+++ b/uv.lock
@@ -45,7 +45,7 @@ requires-dist = [
     { name = "click", specifier = "==8.3.2" },
     { name = "gitpython", specifier = "==3.1.46" },
     { name = "jinja2", specifier = "==3.1.6" },
-    { name = "mypy-primer", git = "https://github.com/hauntsaninja/mypy_primer?rev=850d65d9da947ef9e02498b6f07598e7c8401641" },
+    { name = "mypy-primer", git = "https://github.com/hauntsaninja/mypy_primer?rev=00ded1e9df38b86bf4825457e7fa17d89c215d05" },
 ]
 
 [package.metadata.requires-dev]
@@ -154,7 +154,7 @@ wheels = [
 [[package]]
 name = "mypy-primer"
 version = "0.1.0"
-source = { git = "https://github.com/hauntsaninja/mypy_primer?rev=850d65d9da947ef9e02498b6f07598e7c8401641#850d65d9da947ef9e02498b6f07598e7c8401641" }
+source = { git = "https://github.com/hauntsaninja/mypy_primer?rev=00ded1e9df38b86bf4825457e7fa17d89c215d05#00ded1e9df38b86bf4825457e7fa17d89c215d05" }
 
 [[package]]
 name = "packaging"


### PR DESCRIPTION
Currently projects are distributed across shards based on an alphabetical sort. But that doesn't lead to very well-balanced shards, especially if we [increase the number of shards in CI](https://github.com/astral-sh/ruff/pull/24893): some shards take significantly longer to complete than others, because they have projects in them that take ty a _long_ time to type-check.

This PR uses an approach similar to how mypy_primer is sharded in mypy's and typeshed's CI. Hardcoded values representing the expected costs for ty were added to mypy_primer in https://github.com/hauntsaninja/mypy_primer/pull/246; this PR uses those values to sort the projects list prior to distributing them across the different shards. If a project appears in `flaky.txt`, its cost is multiplied by whatever the `--flaky-runs` specified value was, since the mypy_primer `cost` value only represents the amount of time it's expected to take ty to run on a project once.