### PR TITLE
Use newer Python than 3.11 when necessary

### DIFF
--- a/src/ecosystem_analyzer/config.py
+++ b/src/ecosystem_analyzer/config.py
@@ -2,4 +2,5 @@
 Configuration constants for the ecosystem analyzer.
 """
 
-PYTHON_VERSION = "3.11"
+# Projects may require a newer Python version than this baseline.
+MINIMUM_PYTHON_VERSION = (3, 11)

--- a/src/ecosystem_analyzer/installed_project.py
+++ b/src/ecosystem_analyzer/installed_project.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from git import GitError, Repo
 from mypy_primer.model import Project
 
-from .config import PYTHON_VERSION
+from .config import MINIMUM_PYTHON_VERSION
 
 logger = logging.getLogger(__name__)
 
@@ -188,7 +188,17 @@ class InstalledProject:
 
     def _install_dependencies(self) -> None:
         # Create venv in temporary directory
-        venv_cmd = ["uv", "venv", "--quiet", "--python", PYTHON_VERSION]
+        python_version = max(
+            self._project.min_python_version or MINIMUM_PYTHON_VERSION,
+            MINIMUM_PYTHON_VERSION,
+        )
+        venv_cmd = [
+            "uv",
+            "venv",
+            "--quiet",
+            "--python",
+            ".".join(str(part) for part in python_version),
+        ]
         logger.debug(f"Executing: {' '.join(venv_cmd)}")
         subprocess.run(venv_cmd, check=True, cwd=self._temp_dir.name)
 

--- a/tests/test_exclude_newer.py
+++ b/tests/test_exclude_newer.py
@@ -106,6 +106,27 @@ class TestInstalledProjectExcludeNewer:
         mock_install.assert_called_once()
 
 
+class TestInstallDependenciesPythonVersion:
+    @pytest.mark.parametrize(
+        ("min_python_version", "expected"),
+        [
+            (None, "3.11"),
+            ((3, 10), "3.11"),
+            ((3, 13), "3.13"),
+        ],
+    )
+    @patch("ecosystem_analyzer.installed_project.subprocess.run")
+    @patch.object(InstalledProject, "_clone_or_update")
+    def test_venv_uses_required_python_version(
+        self, _mock_clone, mock_run, min_python_version, expected
+    ):
+        InstalledProject(_make_project(min_python_version=min_python_version))
+
+        venv_call_args = mock_run.call_args_list[0]
+        cmd = venv_call_args.args[0]
+        assert cmd == ["uv", "venv", "--quiet", "--python", expected]
+
+
 class TestInstallDependenciesExcludeNewer:
     """Tests that --exclude-newer is correctly passed to uv pip install commands."""
 


### PR DESCRIPTION
ecosystem-analyzer currently fails to run ty on itself as part of an ecosystem-analyzer run, because it always creates a 3.11 virtual environment for projects, but it can't install itself into a virtual environment on Python <3.13.

The minimum Python version for each project is already given to us by mypy_primer, we just weren't using it

X-ref https://github.com/astral-sh/ruff/pull/25460