### PR TITLE
Remove filtering of "No overload of bound method `__init__` matches arguments" diagnostics

### DIFF
--- a/src/ecosystem_analyzer/diff.py
+++ b/src/ecosystem_analyzer/diff.py
@@ -94,16 +94,6 @@ class DiagnosticDiff:
         with open(file_path) as f:
             data = json.load(f)
 
-        # Filter out diagnostics with specific message:
-        message_filter = "No overload of bound method `__init__` matches arguments"
-        for output in data["outputs"]:
-            if "diagnostics" in output:
-                output["diagnostics"] = [
-                    diag
-                    for diag in output["diagnostics"]
-                    if message_filter not in diag.get("message", "")
-                ]
-
         return data
 
     def _get_commit(self, data: JsonData) -> str:


### PR DESCRIPTION
This filter was added in https://github.com/astral-sh/ecosystem-analyzer/commit/bcdac8a09cfbc23af30818e2b83295aa19432c76. It's not totally clear why -- I suspect we had lots of diagnostics on the ecosystem at that time with that message? It seems like it might be out of date now, anyway, and it produced surprising results on https://github.com/astral-sh/ruff/pull/24560 (see the collapsed Claude analysis in https://github.com/astral-sh/ruff/pull/24560#issuecomment-4260049903). I'm proposing here that we just remove it.