### PR TITLE
Improve diagnostic diff pairing

### DIFF
--- a/src/ecosystem_analyzer/diff.py
+++ b/src/ecosystem_analyzer/diff.py
@@ -745,32 +745,28 @@ class DiagnosticDiff:
                 changed_old_formatted = set()
                 changed_new_formatted = set()
 
-                # Track which new diagnostics have been matched to avoid double-matching
-                matched_new_strs = set()
+                removed_diagnostics = [
+                    d for d in old_diagnostics if self._format_diagnostic(d) in removed
+                ]
+                added_diagnostics = [
+                    d for d in new_diagnostics if self._format_diagnostic(d) in added
+                ]
 
-                # For simplicity, we'll just show all removed and added diagnostics
-                for old_diag in old_diagnostics:
+                for old_diag, new_diag in self._match_changed_diagnostics(
+                    removed_diagnostics, added_diagnostics
+                ):
                     old_str = self._format_diagnostic(old_diag)
-                    if old_str in removed:
-                        for new_diag in new_diagnostics:
-                            new_str = self._format_diagnostic(new_diag)
-                            if (
-                                new_str in added
-                                and new_str not in matched_new_strs
-                                and self._similar_diagnostics(old_diag, new_diag)
-                            ):
-                                # Generate line diff
-                                diff = self._generate_text_diff(old_str, new_str)
-                                if diff:
-                                    text_diffs.append({
-                                        "old": old_diag,
-                                        "new": new_diag,
-                                        "diff": diff,
-                                    })
-                                    changed_old_formatted.add(old_str)
-                                    changed_new_formatted.add(new_str)
-                                    matched_new_strs.add(new_str)
-                                break
+                    new_str = self._format_diagnostic(new_diag)
+                    # Generate line diff
+                    diff = self._generate_text_diff(old_str, new_str)
+                    if diff:
+                        text_diffs.append({
+                            "old": old_diag,
+                            "new": new_diag,
+                            "diff": diff,
+                        })
+                        changed_old_formatted.add(old_str)
+                        changed_new_formatted.add(new_str)
 
                 # Filter out diagnostics that are part of changes
                 removed_diagnostics = [
@@ -804,9 +800,132 @@ class DiagnosticDiff:
 
         return result
 
-    def _similar_diagnostics(self, diag1: Diagnostic, diag2: Diagnostic) -> bool:
-        """Check if two diagnostics are similar (same lint name)."""
-        return diag1["lint_name"] == diag2["lint_name"]
+    def _match_changed_diagnostics(
+        self,
+        old_diagnostics: list[Diagnostic],
+        new_diagnostics: list[Diagnostic],
+    ) -> list[tuple[Diagnostic, Diagnostic]]:
+        """Match rewritten diagnostics by lint while maximizing total similarity."""
+        old_by_lint: dict[str, list[Diagnostic]] = {}
+        new_by_lint: dict[str, list[Diagnostic]] = {}
+        for diag in old_diagnostics:
+            old_by_lint.setdefault(diag["lint_name"], []).append(diag)
+        for diag in new_diagnostics:
+            new_by_lint.setdefault(diag["lint_name"], []).append(diag)
+
+        result = []
+        for lint_name in sorted(old_by_lint.keys() & new_by_lint.keys()):
+            old_group = self._distinct_diagnostics(old_by_lint[lint_name])
+            new_group = self._distinct_diagnostics(new_by_lint[lint_name])
+            result.extend(
+                (old_group[old_index], new_group[new_index])
+                for old_index, new_index in self._maximum_similarity_assignment(
+                    old_group, new_group
+                )
+            )
+        return result
+
+    def _distinct_diagnostics(self, diagnostics: list[Diagnostic]) -> list[Diagnostic]:
+        """Return the first diagnostic for each distinct formatted representation."""
+        result = {}
+        for diag in diagnostics:
+            result.setdefault(self._format_diagnostic(diag), diag)
+        return list(result.values())
+
+    def _maximum_similarity_assignment(
+        self,
+        old_diagnostics: list[Diagnostic],
+        new_diagnostics: list[Diagnostic],
+    ) -> list[tuple[int, int]]:
+        """Assign the smaller diagnostic group to the larger one by total similarity."""
+        if not old_diagnostics or not new_diagnostics:
+            return []
+
+        old_formatted = [self._format_diagnostic(diag) for diag in old_diagnostics]
+        new_formatted = [self._format_diagnostic(diag) for diag in new_diagnostics]
+        assignment_is_transposed = len(old_formatted) > len(new_formatted)
+        # This quadratic matrix is pathological for very large groups, but a single
+        # source line is extremely unlikely to emit enough distinct diagnostics of
+        # one lint for that to matter in ecosystem analysis.
+        if assignment_is_transposed:
+            costs = [
+                [
+                    -difflib.SequenceMatcher(None, old_str, new_str).ratio()
+                    for old_str in old_formatted
+                ]
+                for new_str in new_formatted
+            ]
+        else:
+            costs = [
+                [
+                    -difflib.SequenceMatcher(None, old_str, new_str).ratio()
+                    for new_str in new_formatted
+                ]
+                for old_str in old_formatted
+            ]
+
+        # Hungarian algorithm for a rectangular cost matrix with rows <= columns.
+        row_count = len(costs)
+        column_count = len(costs[0])
+        row_potentials = [0.0] * (row_count + 1)
+        column_potentials = [0.0] * (column_count + 1)
+        matched_rows_by_column = [0] * (column_count + 1)
+        previous_columns = [0] * (column_count + 1)
+
+        for row in range(1, row_count + 1):
+            matched_rows_by_column[0] = row
+            column = 0
+            min_values = [float("inf")] * (column_count + 1)
+            used_columns = [False] * (column_count + 1)
+            while True:
+                used_columns[column] = True
+                matched_row = matched_rows_by_column[column]
+                delta = float("inf")
+                next_column = 0
+                for candidate_column in range(1, column_count + 1):
+                    if used_columns[candidate_column]:
+                        continue
+                    current_value = (
+                        costs[matched_row - 1][candidate_column - 1]
+                        - row_potentials[matched_row]
+                        - column_potentials[candidate_column]
+                    )
+                    if current_value < min_values[candidate_column]:
+                        min_values[candidate_column] = current_value
+                        previous_columns[candidate_column] = column
+                    if min_values[candidate_column] < delta:
+                        delta = min_values[candidate_column]
+                        next_column = candidate_column
+
+                for candidate_column in range(column_count + 1):
+                    if used_columns[candidate_column]:
+                        row_potentials[matched_rows_by_column[candidate_column]] += (
+                            delta
+                        )
+                        column_potentials[candidate_column] -= delta
+                    else:
+                        min_values[candidate_column] -= delta
+                column = next_column
+                if matched_rows_by_column[column] == 0:
+                    break
+
+            while True:
+                previous_column = previous_columns[column]
+                matched_rows_by_column[column] = matched_rows_by_column[previous_column]
+                column = previous_column
+                if column == 0:
+                    break
+
+        assignments = sorted(
+            (matched_rows_by_column[column] - 1, column - 1)
+            for column in range(1, column_count + 1)
+            if matched_rows_by_column[column] != 0
+        )
+        if assignment_is_transposed:
+            return sorted(
+                (old_index, new_index) for new_index, old_index in assignments
+            )
+        return assignments
 
     def _generate_text_diff(self, old_text: str, new_text: str) -> list[str]:
         """Generate a text diff between two strings."""

--- a/src/ecosystem_analyzer/diff.py
+++ b/src/ecosystem_analyzer/diff.py
@@ -821,12 +821,14 @@ class DiagnosticDiff:
         Those messages should appear in the report as one changed diagnostic,
         not as one removal and one addition.
 
-        Only diagnostics with the same lint name can be old and new versions
-        of each other. A line can contain several diagnostics from the same
-        lint, so choose the combination whose messages are most similar
-        overall. If one side has more distinct diagnostics, return one match
-        for each diagnostic on the smaller side. The caller reports anything
-        left over as an addition or removal.
+        Only two diagnostics with the same lint name can be old/new versions
+        of each other. A line can contain several diagnostics with the same
+        error code, so choose the combination whose messages are most similar
+        overall. If one "side" (old vs new) has more distinct diagnostics,
+        return one match for each diagnostic on the smaller side. After we've
+        matched as many "changed diagnostic" pairs as possible, report all
+        remaining diagnostics on the old side as removals and all remaining
+        diagnostics on the new side as additions.
         """
         old_by_lint: dict[str, list[Diagnostic]] = {}
         new_by_lint: dict[str, list[Diagnostic]] = {}
@@ -848,13 +850,14 @@ class DiagnosticDiff:
         return result
 
     def _distinct_diagnostics(self, diagnostics: list[Diagnostic]) -> list[Diagnostic]:
-        """Return the first diagnostic for each distinct formatted string.
+        """Remove exact duplicates before matching old diagnostics to new ones.
 
-        Line comparison is set-based, so repeated instances of the same
-        formatted string represent one changed value. Matching duplicates
-        again here would let one value count more than once and cause false
-        additions or removals. The first instance is enough for choosing the
-        matches.
+        This is called separately for the old and new diagnostics from one line
+        that have the same error code. Multiple diagnostics can produce exactly
+        the same text in the diff report. Those duplicates should count as one
+        possible old/new match; otherwise one value could count more than once
+        and cause false additions or removals. Keep the first diagnostic so it
+        can be included in the report if selected as a match.
         """
         result = {}
         for diag in diagnostics:
@@ -866,14 +869,14 @@ class DiagnosticDiff:
         old_diagnostics: list[Diagnostic],
         new_diagnostics: list[Diagnostic],
     ) -> list[tuple[int, int]]:
-        """Return old/new index pairs whose formatted strings are most similar.
+        """Return old/new index pairs whose diagnostic text is most similar.
 
         For each possible old/new combination, calculate the ``SequenceMatcher``
-        similarity score for the two strings. Then use the Hungarian algorithm
-        to choose the combination with the highest total score, without using
-        any diagnostic more than once. This avoids choosing a good match for
-        the first old diagnostic if that would force worse matches for the
-        remaining diagnostics.
+        similarity score for the diagnostic text. Then use the "Hungarian
+        algorithm" to choose the combination with the highest total score,
+        without using any diagnostic more than once. This avoids choosing a
+        good match for the first old diagnostic if that would force worse
+        matches for the remaining diagnostics.
 
         The two lists can have different lengths. The implementation below
         stores the score for each possible match in a table: one row for each
@@ -898,8 +901,8 @@ class DiagnosticDiff:
         # SequenceMatcher gives larger scores to more similar strings. Store
         # negated scores so the smallest total represents the best matches.
         # Keep the old string as SequenceMatcher's first argument even when a
-        # row represents a new diagnostic: its ratio can depend on argument
-        # order.
+        # row represents a new diagnostic: SequenceMatcher's score can depend
+        # on argument order.
         #
         # The table has one entry for every possible match. A single source
         # line is extremely unlikely to emit enough distinct diagnostics of one
@@ -921,8 +924,8 @@ class DiagnosticDiff:
                 for old_str in old_formatted
             ]
 
-        # This is the Hungarian algorithm linked above. Use one-based indexes
-        # because slot zero is reserved for bookkeeping. Each pass adds a match
+        # This is the Hungarian algorithm linked above. Use 1-based indexes
+        # because slot 0 is reserved for bookkeeping. Each pass adds a match
         # for one more row.
         row_count = len(negated_similarities)
         column_count = len(negated_similarities[0])

--- a/src/ecosystem_analyzer/diff.py
+++ b/src/ecosystem_analyzer/diff.py
@@ -752,6 +752,9 @@ class DiagnosticDiff:
                     d for d in new_diagnostics if self._format_diagnostic(d) in added
                 ]
 
+                # The set difference above has already removed exact matches. Pair
+                # likely rewrites before reporting the remaining diagnostics as
+                # independent removals and additions.
                 for old_diag, new_diag in self._match_changed_diagnostics(
                     removed_diagnostics, added_diagnostics
                 ):
@@ -805,7 +808,18 @@ class DiagnosticDiff:
         old_diagnostics: list[Diagnostic],
         new_diagnostics: list[Diagnostic],
     ) -> list[tuple[Diagnostic, Diagnostic]]:
-        """Match rewritten diagnostics by lint while maximizing total similarity."""
+        """Match removed and added diagnostics that should render as rewrites.
+
+        A rewrite must preserve the lint name. Within each lint group, collapse
+        duplicate formatted diagnostics and find a one-to-one assignment that
+        maximizes the total textual similarity across all pairs. Matching the
+        group globally avoids an early, locally plausible pair from forcing a
+        worse pairing for the remaining diagnostics.
+
+        If the group sizes differ, every member of the smaller group is paired.
+        The caller reports unmatched members of the larger group as additions
+        or removals.
+        """
         old_by_lint: dict[str, list[Diagnostic]] = {}
         new_by_lint: dict[str, list[Diagnostic]] = {}
         for diag in old_diagnostics:
@@ -826,7 +840,13 @@ class DiagnosticDiff:
         return result
 
     def _distinct_diagnostics(self, diagnostics: list[Diagnostic]) -> list[Diagnostic]:
-        """Return the first diagnostic for each distinct formatted representation."""
+        """Collapse duplicate formatted diagnostics while preserving display data.
+
+        Line comparison is set-based, so repeated instances of the same
+        formatted diagnostic represent one changed value. Keeping only the
+        first instance prevents duplicates from cascading into phantom
+        additions or removals after matching.
+        """
         result = {}
         for diag in diagnostics:
             result.setdefault(self._format_diagnostic(diag), diag)
@@ -837,16 +857,34 @@ class DiagnosticDiff:
         old_diagnostics: list[Diagnostic],
         new_diagnostics: list[Diagnostic],
     ) -> list[tuple[int, int]]:
-        """Assign the smaller diagnostic group to the larger one by total similarity."""
+        """Return the old/new index pairs with the greatest total similarity.
+
+        Treat the old and new diagnostics as the two sides of a bipartite
+        graph. Each edge is weighted by the ``SequenceMatcher`` similarity of
+        its formatted diagnostics. This uses the Hungarian algorithm to find a
+        maximum-similarity one-to-one assignment.
+
+        The rectangular implementation requires at most as many rows as
+        columns, so the matrix is transposed when there are more old
+        diagnostics than new diagnostics. Every diagnostic in the smaller
+        group is matched; the caller leaves any unmatched diagnostics in the
+        larger group as additions or removals.
+        """
         if not old_diagnostics or not new_diagnostics:
             return []
 
         old_formatted = [self._format_diagnostic(diag) for diag in old_diagnostics]
         new_formatted = [self._format_diagnostic(diag) for diag in new_diagnostics]
         assignment_is_transposed = len(old_formatted) > len(new_formatted)
-        # This quadratic matrix is pathological for very large groups, but a single
-        # source line is extremely unlikely to emit enough distinct diagnostics of
-        # one lint for that to matter in ecosystem analysis.
+        # The Hungarian algorithm minimizes costs. Negating the similarity
+        # ratios turns the desired maximum-similarity assignment into a
+        # minimum-cost assignment. Keep the old string as SequenceMatcher's
+        # first argument even when the matrix is transposed: its ratio can
+        # depend on argument order.
+        #
+        # This matrix is pathological for very large groups, but a single
+        # source line is extremely unlikely to emit enough distinct
+        # diagnostics of one lint for that to matter in ecosystem analysis.
         if assignment_is_transposed:
             costs = [
                 [
@@ -864,7 +902,9 @@ class DiagnosticDiff:
                 for old_str in old_formatted
             ]
 
-        # Hungarian algorithm for a rectangular cost matrix with rows <= columns.
+        # Hungarian algorithm for a rectangular cost matrix with rows <=
+        # columns. Index zero is a sentinel that anchors the alternating path.
+        # Each outer iteration extends the matching by one row.
         row_count = len(costs)
         column_count = len(costs[0])
         row_potentials = [0.0] * (row_count + 1)
@@ -885,6 +925,8 @@ class DiagnosticDiff:
                 for candidate_column in range(1, column_count + 1):
                     if used_columns[candidate_column]:
                         continue
+                    # Find the cheapest reduced-cost edge leaving the current
+                    # alternating tree.
                     current_value = (
                         costs[matched_row - 1][candidate_column - 1]
                         - row_potentials[matched_row]
@@ -897,6 +939,9 @@ class DiagnosticDiff:
                         delta = min_values[candidate_column]
                         next_column = candidate_column
 
+                # Shift the dual potentials so that at least one more column
+                # becomes reachable without changing the best assignment seen
+                # so far.
                 for candidate_column in range(column_count + 1):
                     if used_columns[candidate_column]:
                         row_potentials[matched_rows_by_column[candidate_column]] += (
@@ -909,6 +954,8 @@ class DiagnosticDiff:
                 if matched_rows_by_column[column] == 0:
                     break
 
+            # Follow the predecessor columns back to the sentinel, augmenting
+            # the matching along the discovered alternating path.
             while True:
                 previous_column = previous_columns[column]
                 matched_rows_by_column[column] = matched_rows_by_column[previous_column]
@@ -916,12 +963,16 @@ class DiagnosticDiff:
                 if column == 0:
                     break
 
+        # Convert the one-indexed column-to-row representation back into
+        # zero-indexed matrix pairs.
         assignments = sorted(
             (matched_rows_by_column[column] - 1, column - 1)
             for column in range(1, column_count + 1)
             if matched_rows_by_column[column] != 0
         )
         if assignment_is_transposed:
+            # Matrix rows represent new diagnostics after transposition. Expose
+            # a consistent (old_index, new_index) API to the caller.
             return sorted(
                 (old_index, new_index) for new_index, old_index in assignments
             )

--- a/src/ecosystem_analyzer/diff.py
+++ b/src/ecosystem_analyzer/diff.py
@@ -752,15 +752,15 @@ class DiagnosticDiff:
                     d for d in new_diagnostics if self._format_diagnostic(d) in added
                 ]
 
-                # The set difference above has already removed exact matches. Pair
-                # likely rewrites before reporting the remaining diagnostics as
-                # independent removals and additions.
+                # Exact string matches are gone. A diagnostic whose text changed
+                # should be reported as one change, not as one removal plus one
+                # addition. Match likely old and new versions before recording
+                # anything left over.
                 for old_diag, new_diag in self._match_changed_diagnostics(
                     removed_diagnostics, added_diagnostics
                 ):
                     old_str = self._format_diagnostic(old_diag)
                     new_str = self._format_diagnostic(new_diag)
-                    # Generate line diff
                     diff = self._generate_text_diff(old_str, new_str)
                     if diff:
                         text_diffs.append({
@@ -808,17 +808,25 @@ class DiagnosticDiff:
         old_diagnostics: list[Diagnostic],
         new_diagnostics: list[Diagnostic],
     ) -> list[tuple[Diagnostic, Diagnostic]]:
-        """Match removed and added diagnostics that should render as rewrites.
+        """Match old diagnostics to new diagnostics when only their text changed.
 
-        A rewrite must preserve the lint name. Within each lint group, collapse
-        duplicate formatted diagnostics and find a one-to-one assignment that
-        maximizes the total textual similarity across all pairs. Matching the
-        group globally avoids an early, locally plausible pair from forcing a
-        worse pairing for the remaining diagnostics.
+        For example, ty might change a message from::
 
-        If the group sizes differ, every member of the smaller group is paired.
-        The caller reports unmatched members of the larger group as additions
-        or removals.
+            Argument to bound method `__init__` is incorrect
+
+        to::
+
+            Argument to `A.__init__` is incorrect
+
+        Those messages should appear in the report as one changed diagnostic,
+        not as one removal and one addition.
+
+        Only diagnostics with the same lint name can be old and new versions
+        of each other. A line can contain several diagnostics from the same
+        lint, so choose the combination whose messages are most similar
+        overall. If one side has more distinct diagnostics, return one match
+        for each diagnostic on the smaller side. The caller reports anything
+        left over as an addition or removal.
         """
         old_by_lint: dict[str, list[Diagnostic]] = {}
         new_by_lint: dict[str, list[Diagnostic]] = {}
@@ -840,12 +848,13 @@ class DiagnosticDiff:
         return result
 
     def _distinct_diagnostics(self, diagnostics: list[Diagnostic]) -> list[Diagnostic]:
-        """Collapse duplicate formatted diagnostics while preserving display data.
+        """Return the first diagnostic for each distinct formatted string.
 
         Line comparison is set-based, so repeated instances of the same
-        formatted diagnostic represent one changed value. Keeping only the
-        first instance prevents duplicates from cascading into phantom
-        additions or removals after matching.
+        formatted string represent one changed value. Matching duplicates
+        again here would let one value count more than once and cause false
+        additions or removals. The first instance is enough for choosing the
+        matches.
         """
         result = {}
         for diag in diagnostics:
@@ -857,36 +866,46 @@ class DiagnosticDiff:
         old_diagnostics: list[Diagnostic],
         new_diagnostics: list[Diagnostic],
     ) -> list[tuple[int, int]]:
-        """Return the old/new index pairs with the greatest total similarity.
+        """Return old/new index pairs whose formatted strings are most similar.
 
-        Treat the old and new diagnostics as the two sides of a bipartite
-        graph. Each edge is weighted by the ``SequenceMatcher`` similarity of
-        its formatted diagnostics. This uses the Hungarian algorithm to find a
-        maximum-similarity one-to-one assignment.
+        For each possible old/new combination, calculate the ``SequenceMatcher``
+        similarity score for the two strings. Then use the Hungarian algorithm
+        to choose the combination with the highest total score, without using
+        any diagnostic more than once. This avoids choosing a good match for
+        the first old diagnostic if that would force worse matches for the
+        remaining diagnostics.
 
-        The rectangular implementation requires at most as many rows as
-        columns, so the matrix is transposed when there are more old
-        diagnostics than new diagnostics. Every diagnostic in the smaller
-        group is matched; the caller leaves any unmatched diagnostics in the
-        larger group as additions or removals.
+        The two lists can have different lengths. The implementation below
+        stores the score for each possible match in a table: one row for each
+        diagnostic in the shorter list and one column for each diagnostic in
+        the longer list. It matches every row to one column. The caller reports
+        diagnostics represented only by unused columns as additions or
+        removals.
+
+        ``SequenceMatcher``:
+        https://docs.python.org/3/library/difflib.html#difflib.SequenceMatcher
+
+        Hungarian algorithm:
+        https://en.wikipedia.org/wiki/Hungarian_algorithm
         """
         if not old_diagnostics or not new_diagnostics:
             return []
 
         old_formatted = [self._format_diagnostic(diag) for diag in old_diagnostics]
         new_formatted = [self._format_diagnostic(diag) for diag in new_diagnostics]
-        assignment_is_transposed = len(old_formatted) > len(new_formatted)
-        # The Hungarian algorithm minimizes costs. Negating the similarity
-        # ratios turns the desired maximum-similarity assignment into a
-        # minimum-cost assignment. Keep the old string as SequenceMatcher's
-        # first argument even when the matrix is transposed: its ratio can
-        # depend on argument order.
+        rows_are_new_diagnostics = len(old_formatted) > len(new_formatted)
+        # The implementation below chooses the smallest numbers, whereas
+        # SequenceMatcher gives larger scores to more similar strings. Store
+        # negated scores so the smallest total represents the best matches.
+        # Keep the old string as SequenceMatcher's first argument even when a
+        # row represents a new diagnostic: its ratio can depend on argument
+        # order.
         #
-        # This matrix is pathological for very large groups, but a single
-        # source line is extremely unlikely to emit enough distinct
-        # diagnostics of one lint for that to matter in ecosystem analysis.
-        if assignment_is_transposed:
-            costs = [
+        # The table has one entry for every possible match. A single source
+        # line is extremely unlikely to emit enough distinct diagnostics of one
+        # lint for the table size to matter in ecosystem analysis.
+        if rows_are_new_diagnostics:
+            negated_similarities = [
                 [
                     -difflib.SequenceMatcher(None, old_str, new_str).ratio()
                     for old_str in old_formatted
@@ -894,7 +913,7 @@ class DiagnosticDiff:
                 for new_str in new_formatted
             ]
         else:
-            costs = [
+            negated_similarities = [
                 [
                     -difflib.SequenceMatcher(None, old_str, new_str).ratio()
                     for new_str in new_formatted
@@ -902,13 +921,13 @@ class DiagnosticDiff:
                 for old_str in old_formatted
             ]
 
-        # Hungarian algorithm for a rectangular cost matrix with rows <=
-        # columns. Index zero is a sentinel that anchors the alternating path.
-        # Each outer iteration extends the matching by one row.
-        row_count = len(costs)
-        column_count = len(costs[0])
-        row_potentials = [0.0] * (row_count + 1)
-        column_potentials = [0.0] * (column_count + 1)
+        # This is the Hungarian algorithm linked above. Use one-based indexes
+        # because slot zero is reserved for bookkeeping. Each pass adds a match
+        # for one more row.
+        row_count = len(negated_similarities)
+        column_count = len(negated_similarities[0])
+        row_offsets = [0.0] * (row_count + 1)
+        column_offsets = [0.0] * (column_count + 1)
         matched_rows_by_column = [0] * (column_count + 1)
         previous_columns = [0] * (column_count + 1)
 
@@ -925,12 +944,10 @@ class DiagnosticDiff:
                 for candidate_column in range(1, column_count + 1):
                     if used_columns[candidate_column]:
                         continue
-                    # Find the cheapest reduced-cost edge leaving the current
-                    # alternating tree.
                     current_value = (
-                        costs[matched_row - 1][candidate_column - 1]
-                        - row_potentials[matched_row]
-                        - column_potentials[candidate_column]
+                        negated_similarities[matched_row - 1][candidate_column - 1]
+                        - row_offsets[matched_row]
+                        - column_offsets[candidate_column]
                     )
                     if current_value < min_values[candidate_column]:
                         min_values[candidate_column] = current_value
@@ -939,23 +956,20 @@ class DiagnosticDiff:
                         delta = min_values[candidate_column]
                         next_column = candidate_column
 
-                # Shift the dual potentials so that at least one more column
-                # becomes reachable without changing the best assignment seen
-                # so far.
+                # Update the bookkeeping offsets before considering the next
+                # available column.
                 for candidate_column in range(column_count + 1):
                     if used_columns[candidate_column]:
-                        row_potentials[matched_rows_by_column[candidate_column]] += (
-                            delta
-                        )
-                        column_potentials[candidate_column] -= delta
+                        row_offsets[matched_rows_by_column[candidate_column]] += delta
+                        column_offsets[candidate_column] -= delta
                     else:
                         min_values[candidate_column] -= delta
                 column = next_column
                 if matched_rows_by_column[column] == 0:
                     break
 
-            # Follow the predecessor columns back to the sentinel, augmenting
-            # the matching along the discovered alternating path.
+            # Save the new match. Following previous_columns may move earlier
+            # matches to different columns to make room for it.
             while True:
                 previous_column = previous_columns[column]
                 matched_rows_by_column[column] = matched_rows_by_column[previous_column]
@@ -963,16 +977,16 @@ class DiagnosticDiff:
                 if column == 0:
                     break
 
-        # Convert the one-indexed column-to-row representation back into
-        # zero-indexed matrix pairs.
+        # Convert the one-based bookkeeping indexes back into indexes for the
+        # input lists.
         assignments = sorted(
             (matched_rows_by_column[column] - 1, column - 1)
             for column in range(1, column_count + 1)
             if matched_rows_by_column[column] != 0
         )
-        if assignment_is_transposed:
-            # Matrix rows represent new diagnostics after transposition. Expose
-            # a consistent (old_index, new_index) API to the caller.
+        if rows_are_new_diagnostics:
+            # Rows represent new diagnostics in this case. Swap the indexes so
+            # callers always receive (old_index, new_index).
             return sorted(
                 (old_index, new_index) for new_index, old_index in assignments
             )

--- a/tests/test_json_roundtrip.py
+++ b/tests/test_json_roundtrip.py
@@ -788,6 +788,131 @@ info: Args: /tmp/new_commit/ty check ."""
         assert "flaky_diffs" not in proj
         assert "flaky_file_diffs" not in proj
 
+    def test_duplicate_diagnostics_do_not_cascade_into_phantom_removals(self):
+        def make_diag(message):
+            return {
+                "level": "error",
+                "lint_name": "invalid-argument-type",
+                "path": "a.py",
+                "line": 1,
+                "column": 1,
+                "message": message,
+            }
+
+        old_int = "Argument to bound method `__init__` is incorrect: Expected `int`"
+        old_str = "Argument to bound method `__init__` is incorrect: Expected `str`"
+        new_int = "Argument to `Z.__init__` is incorrect: Expected `int`"
+        new_str = "Argument to `A.__init__` is incorrect: Expected `str`"
+        old_data = {
+            "outputs": [
+                _make_output(
+                    "proj", [make_diag(old_int), make_diag(old_int), make_diag(old_str)]
+                )
+            ]
+        }
+        new_data = {
+            "outputs": [
+                _make_output(
+                    "proj", [make_diag(new_int), make_diag(new_int), make_diag(new_str)]
+                )
+            ]
+        }
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f1:
+            json.dump(old_data, f1)
+            old_path = f1.name
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f2:
+            json.dump(new_data, f2)
+            new_path = f2.name
+
+        diff = DiagnosticDiff(old_path, new_path)
+        stats = diff._calculate_statistics()
+        modified_line = diff.diffs["modified_projects"][0]["diffs"]["modified_files"][
+            0
+        ]["diffs"]["modified_lines"][0]
+
+        assert stats["total_changed"] == 2
+        assert stats["total_added"] == 0
+        assert stats["total_removed"] == 0
+        assert {
+            (item["old"]["message"], item["new"]["message"])
+            for item in modified_line["text_diffs"]
+        } == {(old_int, new_int), (old_str, new_str)}
+
+    def test_competing_rewritten_diagnostics_are_matched_globally(self):
+        def make_diag(message):
+            return {
+                "level": "error",
+                "lint_name": "invalid-assignment",
+                "path": "a.py",
+                "line": 1,
+                "column": 1,
+                "message": message,
+            }
+
+        old_int = "Expected int"
+        old_str = "Expected str"
+        new_int = "Expected int | None."
+        new_str = "Expected str."
+        old_data = {
+            "outputs": [_make_output("proj", [make_diag(old_int), make_diag(old_str)])]
+        }
+        new_data = {
+            "outputs": [_make_output("proj", [make_diag(new_int), make_diag(new_str)])]
+        }
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f1:
+            json.dump(old_data, f1)
+            old_path = f1.name
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f2:
+            json.dump(new_data, f2)
+            new_path = f2.name
+
+        diff = DiagnosticDiff(old_path, new_path)
+        modified_line = diff.diffs["modified_projects"][0]["diffs"]["modified_files"][
+            0
+        ]["diffs"]["modified_lines"][0]
+
+        assert {
+            (item["old"]["message"], item["new"]["message"])
+            for item in modified_line["text_diffs"]
+        } == {(old_int, new_int), (old_str, new_str)}
+
+    def test_rectangular_matching_preserves_old_to_new_similarity_direction(self):
+        def make_diag(message):
+            return {
+                "level": "error",
+                "lint_name": "invalid-assignment",
+                "path": "a.py",
+                "line": 1,
+                "column": 1,
+                "message": message,
+            }
+
+        old_data = {
+            "outputs": [_make_output("proj", [make_diag("aaa"), make_diag("babba")])]
+        }
+        new_data = {"outputs": [_make_output("proj", [make_diag("aba")])]}
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f1:
+            json.dump(old_data, f1)
+            old_path = f1.name
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f2:
+            json.dump(new_data, f2)
+            new_path = f2.name
+
+        diff = DiagnosticDiff(old_path, new_path)
+        modified_line = diff.diffs["modified_projects"][0]["diffs"]["modified_files"][
+            0
+        ]["diffs"]["modified_lines"][0]
+
+        assert [
+            (item["old"]["message"], item["new"]["message"])
+            for item in modified_line["text_diffs"]
+        ] == [("aaa", "aba")]
+        assert [item["message"] for item in modified_line["removed"]] == ["babba"]
+        assert modified_line["added"] == []
+
     def test_statistics_markdown_includes_large_timing_changes(self):
         old_data = {
             "outputs": [

--- a/tests/test_json_roundtrip.py
+++ b/tests/test_json_roundtrip.py
@@ -789,6 +789,8 @@ info: Args: /tmp/new_commit/ty check ."""
         assert "flaky_file_diffs" not in proj
 
     def test_duplicate_diagnostics_do_not_cascade_into_phantom_removals(self):
+        """Repeated representations are matched once without leaving duplicate noise."""
+
         def make_diag(message):
             return {
                 "level": "error",
@@ -840,6 +842,8 @@ info: Args: /tmp/new_commit/ty check ."""
         } == {(old_int, new_int), (old_str, new_str)}
 
     def test_competing_rewritten_diagnostics_are_matched_globally(self):
+        """Competing rewrites are paired by the best assignment for the whole group."""
+
         def make_diag(message):
             return {
                 "level": "error",
@@ -879,6 +883,8 @@ info: Args: /tmp/new_commit/ty check ."""
         } == {(old_int, new_int), (old_str, new_str)}
 
     def test_rectangular_matching_preserves_old_to_new_similarity_direction(self):
+        """Transposed assignments still calculate similarity from old text to new text."""
+
         def make_diag(message):
             return {
                 "level": "error",


### PR DESCRIPTION
## Summary

Fix misleading diagnostic diff reports when ty changes the text of several diagnostics on the same source line.

For example, ty might change a diagnostic message from:

```text
Argument to bound method `__init__` is incorrect
```

to:

```text
Argument to `A.__init__` is incorrect
```

The report should show that as one changed diagnostic, not as one removed diagnostic plus one added diagnostic.

This addresses the second `ecosystem-analyzer` artifact identified while investigating the ecosystem report for [`ruff` PR #24560][ruff-pr-24560-comment]. It intentionally does not address the separate hardcoded `__init__` overload-filter artifact described in the same comment.

## Problem

`_compare_lines` first removes diagnostics whose text is identical in the old and new reports. For the diagnostics left over, it tries to decide which old diagnostics and new diagnostics are different versions of the same diagnostic. It can then render a text diff for each changed diagnostic and report anything left over on the old side as a removal or on the new side as an addition.

Only two diagnostics with the same error code can be old/new versions of each other. However, one source line can contain several diagnostics with the same error code. It can also contain exact duplicate messages. This is common for constructor calls with union-typed `**kwargs` values.

Previously, `ecosystem-analyzer` considered the old diagnostics one at a time. Each old diagnostic claimed the first available new diagnostic with the same error code. That can produce the wrong result:

1. The first copy of an old message claims its expected new version.
2. A duplicate old message claims a different new message with the same error code.
3. The old message that should have claimed that new message is forced to claim another one.
4. The mismatch continues until later old diagnostics are left unmatched and incorrectly reported as removals.

The report can therefore show removed diagnostics even when the old and new runs contain the same logical diagnostics with text-only changes.

## New Matching Algorithm

For each error code on a modified source line, `ecosystem-analyzer` now:

1. removes exact duplicate messages from the old and new sides;
2. uses [`difflib.SequenceMatcher`][sequence-matcher] to calculate how similar each possible old/new combination is;
3. uses the [Hungarian algorithm][hungarian-algorithm] to select the combination of matches with the highest total similarity, without using any diagnostic more than once;
4. reports each selected old/new match as one changed diagnostic;
5. reports unmatched old diagnostics as removals and unmatched new diagnostics as additions.

The implementation stores the similarity scores in a table. The shorter list of diagnostics supplies the table rows and the longer list supplies the columns, so every diagnostic on the shorter side can be matched once. If the old side is longer, the rows therefore represent new diagnostics. The code still calculates each similarity score in old-to-new order because `SequenceMatcher` can produce a different score when its arguments are reversed.

As before, there is no minimum similarity threshold: every diagnostic on the shorter side is matched to one diagnostic on the longer side when the error codes are the same. The behavioral change is that duplicate messages no longer distort the result, and matches are selected together rather than one at a time.

## Tests

Added regressions covering:

- duplicate diagnostics no longer cascading into false removals;
- several same-error-code diagnostics being matched using the best combination for the whole group rather than one at a time;
- similarity scores still being calculated in old-to-new order when the old side contains more diagnostics than the new side.

[ruff-pr-24560-comment]: https://github.com/astral-sh/ruff/pull/24560#issuecomment-4260049903
[sequence-matcher]: https://docs.python.org/3/library/difflib.html#difflib.SequenceMatcher
[hungarian-algorithm]: https://en.wikipedia.org/wiki/Hungarian_algorithm
