### PR TITLE
Add project kind metadata to reports

### DIFF
--- a/src/ecosystem_analyzer/diff.py
+++ b/src/ecosystem_analyzer/diff.py
@@ -408,7 +408,7 @@ class DiagnosticDiff:
                 else:
                     failure_status = "persistent"
 
-                result["failed_projects"].append({
+                entry = {
                     "project": project_name,
                     "project_location": new_project.get("project_location", ""),
                     "old_status": old_status,
@@ -423,7 +423,9 @@ class DiagnosticDiff:
                     "fixed_panic_messages": fixed_panics,
                     "persistent_panic_messages": persistent_panics,
                     "failure_status": failure_status,
-                })
+                }
+                self._add_project_kind(entry, new_project)
+                result["failed_projects"].append(entry)
                 # Skip detailed diff analysis for failed projects
                 continue
 
@@ -446,6 +448,7 @@ class DiagnosticDiff:
                     "project_location": project_data.get("project_location", ""),
                     "diagnostics": diagnostics,
                 }
+                self._add_project_kind(entry, project_data)
                 flaky = project_data.get("flaky_diagnostics", [])
                 if flaky:
                     entry["flaky_diagnostics"] = flaky
@@ -471,6 +474,7 @@ class DiagnosticDiff:
                     "project_location": project_data.get("project_location", ""),
                     "diagnostics": diagnostics,
                 }
+                self._add_project_kind(entry, project_data)
                 flaky = project_data.get("flaky_diagnostics", [])
                 if flaky:
                     entry["flaky_diagnostics"] = flaky
@@ -550,6 +554,7 @@ class DiagnosticDiff:
                     "project_location": new_project.get("project_location", ""),
                     "diffs": file_diffs,
                 }
+                self._add_project_kind(entry, new_project)
                 if has_flaky_changes:
                     entry["flaky_diffs"] = flaky_diffs
                     entry["flaky_file_diffs"] = self._organize_flaky_diffs_by_file(
@@ -590,6 +595,16 @@ class DiagnosticDiff:
         result["failed_projects"].sort(key=failed_project_sort_key)
 
         return result
+
+    @staticmethod
+    def _project_kind(output: RunOutput) -> str | None:
+        metadata = output.get("project_metadata")
+        return metadata.get("kind") if metadata is not None else None
+
+    @classmethod
+    def _add_project_kind(cls, entry: dict[str, Any], output: RunOutput) -> None:
+        if kind := cls._project_kind(output):
+            entry["project_metadata"] = {"kind": kind}
 
     def _group_diagnostics_by_file(
         self, diagnostics: list[Diagnostic]
@@ -1484,6 +1499,11 @@ class DiagnosticDiff:
             "failure_descriptor": _failure_descriptor,
             "failure_status_labels": _FAILURE_STATUS_LABELS,
             "failure_status_titles": _FAILURE_STATUS_TITLES,
+            "project_kinds": sorted({
+                kind
+                for output in chain(self.old_data["outputs"], self.new_data["outputs"])
+                if (kind := self._project_kind(output))
+            }),
         }
 
         # Ensure the output directory exists

--- a/src/ecosystem_analyzer/run_output.py
+++ b/src/ecosystem_analyzer/run_output.py
@@ -3,6 +3,10 @@ from typing import NotRequired, TypedDict
 from .diagnostic import Diagnostic
 
 
+class ProjectMetadata(TypedDict):
+    kind: NotRequired[str]
+
+
 class FlakyVariant(TypedDict):
     """A diagnostic variant seen at a flaky location, with its frequency."""
 
@@ -30,3 +34,4 @@ class RunOutput(TypedDict):
     return_code: int | None
     stderr: NotRequired[str]
     panic_messages: NotRequired[list[str]]
+    project_metadata: NotRequired[ProjectMetadata]

--- a/src/ecosystem_analyzer/templates/diff.html
+++ b/src/ecosystem_analyzer/templates/diff.html
@@ -751,6 +751,14 @@
                     {% endfor %}
                     {% endif %}
                 </select>
+                {% if project_kinds %}
+                <select class="filter-select" id="project-kind-filter">
+                    <option value="all">All Project Kinds</option>
+                    {% for project_kind in project_kinds %}
+                    <option value="{{ project_kind }}">{{ project_kind }}</option>
+                    {% endfor %}
+                </select>
+                {% endif %}
             </div>
         </div>
 
@@ -879,7 +887,7 @@
         {% if diffs.added_projects %}
         <h2>Added Projects</h2>
         {% for project in diffs.added_projects %}
-        <div class="project added">
+        <div class="project added"{% if project.project_metadata is defined and project.project_metadata.kind is defined %} data-project-kind="{{ project.project_metadata.kind }}"{% endif %}>
             <h3>{{ project.project }} <small>(<a href="{{ project.project_location }}" target="_blank">{{ project.project_location }}</a>)</small></h3>
             {% set file_groups = project.diagnostics|groupby('path') %}
             {% for path, diagnostics in file_groups %}
@@ -900,7 +908,7 @@
         {% if diffs.removed_projects %}
         <h2>Removed Projects</h2>
         {% for project in diffs.removed_projects %}
-        <div class="project removed">
+        <div class="project removed"{% if project.project_metadata is defined and project.project_metadata.kind is defined %} data-project-kind="{{ project.project_metadata.kind }}"{% endif %}>
             <h3>{{ project.project }} <small>(<a href="{{ project.project_location }}" target="_blank">{{ project.project_location }}</a>)</small></h3>
             {% set file_groups = project.diagnostics|groupby('path') %}
             {% for path, diagnostics in file_groups %}
@@ -920,7 +928,7 @@
 
         {% if diffs.modified_projects %}
         {% for project in diffs.modified_projects %}
-        <div class="project modified">
+        <div class="project modified"{% if project.project_metadata is defined and project.project_metadata.kind is defined %} data-project-kind="{{ project.project_metadata.kind }}"{% endif %}>
             <h3>{{ project.project }} <small>(<a href="{{ project.project_location }}" target="_blank">{{ project.project_location }}</a>)</small></h3>
             {% if project.diffs.added_files %}
             {% for file_data in project.diffs.added_files %}
@@ -1104,10 +1112,12 @@
             const filterButtons = document.querySelectorAll('.filter-btn');
             const lintFilter = document.getElementById('lint-filter');
             const projectFilter = document.getElementById('project-filter');
+            const projectKindFilter = document.getElementById('project-kind-filter');
 
             let activeChangeFilter = 'all';
             let activeLintFilter = 'all';
             let activeProjectFilter = 'all';
+            let activeProjectKindFilter = 'all';
 
             // Change type filter buttons
             filterButtons.forEach(button => {
@@ -1134,6 +1144,14 @@
                 applyFilters();
             });
 
+            // Project kind filter dropdown
+            if (projectKindFilter) {
+                projectKindFilter.addEventListener('change', function() {
+                    activeProjectKindFilter = this.value;
+                    applyFilters();
+                });
+            }
+
             function applyFilters() {
                 const diagnostics = document.querySelectorAll('.diagnostic');
 
@@ -1141,10 +1159,13 @@
                     const changeType = diagnostic.dataset.changeType;
                     const lintName = diagnostic.dataset.lintName;
                     const projectName = diagnostic.dataset.projectName;
+                    const project = diagnostic.closest('.project');
+                    const projectKind = project.dataset.projectKind;
 
                     let showByChange = true;
                     let showByLint = true;
                     let showByProject = true;
+                    let showByProjectKind = true;
 
                     // Apply change type filter
                     if (activeChangeFilter !== 'all') {
@@ -1161,8 +1182,13 @@
                         showByProject = projectName === activeProjectFilter;
                     }
 
+                    // Apply project kind filter
+                    if (activeProjectKindFilter !== 'all') {
+                        showByProjectKind = projectKind === activeProjectKindFilter;
+                    }
+
                     // Show/hide diagnostic
-                    if (showByChange && showByLint && showByProject) {
+                    if (showByChange && showByLint && showByProject && showByProjectKind) {
                         diagnostic.style.display = '';
                         diagnostic.closest('.file').style.display = '';
                         diagnostic.closest('.project').style.display = '';

--- a/tests/test_json_roundtrip.py
+++ b/tests/test_json_roundtrip.py
@@ -1,5 +1,7 @@
 import json
 import tempfile
+from pathlib import Path
+from typing import Any
 
 from ecosystem_analyzer.diff import DiagnosticDiff
 
@@ -13,8 +15,9 @@ def _make_output(
     stderr: str | None = None,
     time_s: float | None = 1.5,
     return_code: int | None = 1,
+    project_metadata: dict | None = None,
 ):
-    entry = {
+    entry: dict[str, Any] = {
         "project": project,
         "project_location": f"https://github.com/example/{project}",
         "ty_commit": "abc123def456",
@@ -30,6 +33,8 @@ def _make_output(
         entry["panic_messages"] = panic_messages
     if stderr is not None:
         entry["stderr"] = stderr
+    if project_metadata is not None:
+        entry["project_metadata"] = project_metadata
     return entry
 
 
@@ -90,6 +95,56 @@ def _render_html(diff: DiagnosticDiff) -> str:
 
 
 class TestJsonRoundtrip:
+    def test_project_metadata_is_rendered_as_filterable_html(self):
+        old_data = {
+            "outputs": [
+                _make_output(
+                    "example-project",
+                    [],
+                    project_metadata={"kind": "example-kind"},
+                )
+            ]
+        }
+        new_data = {
+            "outputs": [
+                _make_output(
+                    "example-project",
+                    [
+                        {
+                            "level": "error",
+                            "lint_name": "some-lint",
+                            "path": "a.py",
+                            "line": 1,
+                            "column": 1,
+                            "message": "new",
+                        }
+                    ],
+                    project_metadata={"kind": "example-kind"},
+                )
+            ]
+        }
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f1:
+            json.dump(old_data, f1)
+            old_path = f1.name
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f2:
+            json.dump(new_data, f2)
+            new_path = f2.name
+        with tempfile.NamedTemporaryFile(
+            mode="r", suffix=".html", delete=False
+        ) as html:
+            html_path = html.name
+
+        diff = DiagnosticDiff(old_path, new_path)
+        diff.generate_html_report(html_path)
+        rendered = Path(html_path).read_text()
+
+        assert 'id="project-kind-filter"' in rendered
+        assert 'data-project-kind="example-kind"' in rendered
+        assert diff.diffs["modified_projects"][0]["project_metadata"] == {
+            "kind": "example-kind"
+        }
+
     def test_roundtrip_without_flaky(self):
         """JSON files without flaky data load and diff correctly."""
         diag = {


### PR DESCRIPTION
## Summary

add an optional `project_metadata.kind` field to diagnostic run output that can be used for interactive filtering.
