### PR TITLE
Detect flaky exit status changes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,12 @@ Use `uv` for all local work.
 - `uv run ecosystem-analyzer --repository ~/ty run --project-name <project> --commit <ty-commit> --output project-diagnostics.json`: analyze one project against a `ty` checkout.
 - `uv run ecosystem-analyzer generate-report project-diagnostics.json --output report.html`: render an HTML report from saved diagnostics.
 
+## Compatibility Policy
+
+This project has no public, stable API. Retaining compatibility code for old CLI behavior, output schemas, or other internal interfaces is unnecessary and undesirable; prefer updating callers and removing obsolete paths.
+
+The maintainers of this project are also the maintainers of Ruff and `ty`. We can easily update how `ecosystem-analyzer` is installed and invoked by the GitHub workflows in the Ruff repository, so those workflows should not be treated as a reason to preserve otherwise-unnecessary compatibility code here.
+
 ## `ty` CI Integration
 
 `ty` uses `ecosystem-analyzer` from the `ruff` repository's CI workflow at [`.github/workflows/ty-ecosystem-analyzer.yaml`](https://github.com/astral-sh/ruff/blob/main/.github/workflows/ty-ecosystem-analyzer.yaml).

--- a/src/ecosystem_analyzer/diagnostic.py
+++ b/src/ecosystem_analyzer/diagnostic.py
@@ -13,6 +13,31 @@ NEW_DIAGNOSTIC_PATTERN = re.compile(
     r"(?P<message>.+)$"
 )
 PANIC_PATTERN = re.compile(r"^(?:error|fatal)\[panic\](?::)? (?P<message>.+)$")
+_RUST_SOURCE_LOCATION_PATTERN = re.compile(r"(?P<path>\S+\.rs):\d+(?::\d+)?")
+_PANIC_TRACE_HEADERS = {"info: Backtrace:", "info: query stacktrace:"}
+_VOLATILE_PANIC_METADATA_PREFIXES = ("info: Version:", "info: Args:")
+
+
+def normalize_panic_message(message: str) -> str:
+    """Remove volatile details before comparing panic messages."""
+    stable_lines = []
+    for line in message.splitlines():
+        stripped = line.strip()
+        if stripped in _PANIC_TRACE_HEADERS:
+            break
+        if stripped.startswith(_VOLATILE_PANIC_METADATA_PREFIXES):
+            continue
+        stable_lines.append(_RUST_SOURCE_LOCATION_PATTERN.sub(r"\g<path>:<line>", line))
+    return "\n".join(stable_lines)
+
+
+def index_panic_messages(messages: list[str]) -> dict[str, list[str]]:
+    """Group raw panic messages by their normalized comparison key."""
+    indexed_messages: dict[str, list[str]] = {}
+    for message in messages:
+        key = normalize_panic_message(message)
+        indexed_messages.setdefault(key, []).append(message)
+    return indexed_messages
 
 
 class Diagnostic(TypedDict):

--- a/src/ecosystem_analyzer/diff.py
+++ b/src/ecosystem_analyzer/diff.py
@@ -2,16 +2,16 @@ import difflib
 import json
 import os
 import random
-import re
 from collections import Counter
+from enum import Enum
 from itertools import chain
 from pathlib import Path
 from typing import Any, Literal, TypedDict
 
 from jinja2 import Environment, FileSystemLoader, PackageLoader
 
-from .diagnostic import Diagnostic
-from .run_output import RunOutput
+from .diagnostic import Diagnostic, index_panic_messages
+from .run_output import ExitStatus, OutputVariant, RunOutput
 
 
 class JsonData(TypedDict):
@@ -70,39 +70,20 @@ _FAILURE_STATUS_TITLES = {
     "fixed": "Failure that existed on the baseline is no longer present",
 }
 
-_RUST_SOURCE_LOCATION_PATTERN = re.compile(r"(?P<path>\S+\.rs):\d+(?::\d+)?")
-_PANIC_TRACE_HEADERS = {"info: Backtrace:", "info: query stacktrace:"}
-_VOLATILE_PANIC_METADATA_PREFIXES = ("info: Version:", "info: Args:")
 
-
-def _normalize_panic_message(message: str) -> str:
-    """Remove volatile details before comparing panic messages."""
-    stable_lines = []
-    for line in message.splitlines():
-        stripped = line.strip()
-        if stripped in _PANIC_TRACE_HEADERS:
-            break
-        if stripped.startswith(_VOLATILE_PANIC_METADATA_PREFIXES):
-            continue
-        stable_lines.append(_RUST_SOURCE_LOCATION_PATTERN.sub(r"\g<path>:<line>", line))
-    return "\n".join(stable_lines)
-
-
-def _index_panic_messages(messages: list[str]) -> dict[str, list[str]]:
-    """Group raw panic messages by their normalized comparison key."""
-    indexed_messages: dict[str, list[str]] = {}
-    for message in messages:
-        key = _normalize_panic_message(message)
-        indexed_messages.setdefault(key, []).append(message)
-    return indexed_messages
+class _ProjectStatus(Enum):
+    SUCCESS = "success"
+    TIMEOUT = "timeout"
+    ABNORMAL_EXIT = "abnormal exit"
+    FLAKY = "flaky"
 
 
 def _compare_panic_messages(
     old_messages: list[str], new_messages: list[str]
 ) -> tuple[list[str], list[str], list[str]]:
     """Return introduced, fixed, and persistent panic messages."""
-    old_messages_by_key = _index_panic_messages(old_messages)
-    new_messages_by_key = _index_panic_messages(new_messages)
+    old_messages_by_key = index_panic_messages(old_messages)
+    new_messages_by_key = index_panic_messages(new_messages)
     introduced = []
     fixed = []
     persistent = []
@@ -341,16 +322,148 @@ class DiagnosticDiff:
             f"{diag['path']}:{diag['line']}:{diag['column']} - {diag['message']}"
         )
 
-    def _is_project_failed(self, project_data: RunOutput) -> tuple[bool, str]:
-        """Check if a project failed (timeout or abnormal exit) and return status."""
-        return_code = project_data.get("return_code")
-        time_s = project_data.get("time_s")
+    def _exit_statuses(self, project_data: RunOutput) -> list[ExitStatus]:
+        """Return the project's observed exit statuses."""
+        return project_data["exit_statuses"]
 
-        if return_code is None:
-            return True, "timeout"
-        if return_code not in (0, 1) or time_s is None:
-            return True, "abnormal exit"
-        return False, "success"
+    def _total_runs(self, project_data: RunOutput) -> int:
+        """Return the number of runs represented by an output."""
+        return sum(status["count"] for status in self._exit_statuses(project_data))
+
+    def _format_exit_statuses(self, statuses: list[ExitStatus]) -> str:
+        """Format observed exit statuses for Markdown and raw diff output."""
+        total = sum(status["count"] for status in statuses)
+        parts = []
+        for status in statuses:
+            label = (
+                "timeout"
+                if status["return_code"] is None
+                else f"exit {status['return_code']}"
+            )
+            if len(statuses) > 1:
+                label += f" ({status['count']}/{total})"
+            parts.append(label)
+        return ", ".join(parts)
+
+    def _stable_panic_messages(self, project_data: RunOutput) -> list[str]:
+        """Return panic identities present in every represented run."""
+        statuses = self._exit_statuses(project_data)
+        variants_by_status = []
+        all_keys = set()
+        for status in statuses:
+            variants_by_key: dict[str, list[OutputVariant]] = {}
+            for variant in status.get("panic_messages", []):
+                [key] = index_panic_messages([variant["message"]])
+                all_keys.add(key)
+                variants_by_key.setdefault(key, []).append(variant)
+            variants_by_status.append(variants_by_key)
+
+        stable = []
+        for key in all_keys:
+            stable_multiplicity = min(
+                sum(
+                    variant["count"] == status["count"]
+                    for variant in variants.get(key, [])
+                )
+                for status, variants in zip(statuses, variants_by_status, strict=True)
+            )
+            representatives = [
+                variant["message"]
+                for variants in variants_by_status
+                for variant in variants.get(key, [])
+            ]
+            stable.extend(representatives[:stable_multiplicity])
+        return sorted(stable)
+
+    def _project_status(self, project_data: RunOutput) -> _ProjectStatus:
+        """Return the project's aggregate exit status."""
+        has_normal_exit = any(
+            status["return_code"] in (0, 1)
+            for status in self._exit_statuses(project_data)
+        )
+        has_abnormal_exit = any(
+            status["return_code"] not in (0, 1)
+            for status in self._exit_statuses(project_data)
+        )
+        if has_normal_exit and has_abnormal_exit:
+            return _ProjectStatus.FLAKY
+        if not has_abnormal_exit:
+            return _ProjectStatus.SUCCESS
+
+        return_codes = {
+            status["return_code"] for status in self._exit_statuses(project_data)
+        }
+        if return_codes == {None}:
+            return _ProjectStatus.TIMEOUT
+        return _ProjectStatus.ABNORMAL_EXIT
+
+    def _has_flaky_exit_evidence(self, project_data: RunOutput) -> bool:
+        """Return whether exit outcomes or their evidence varied between runs."""
+        statuses = self._exit_statuses(project_data)
+        if len(statuses) > 1:
+            return True
+        return any(
+            variant["count"] != status["count"]
+            for status in statuses
+            for variant in chain(
+                status.get("panic_messages", []), status.get("stderr", [])
+            )
+        )
+
+    def _compare_flaky_exit_statuses(
+        self, old_project: RunOutput, new_project: RunOutput
+    ) -> dict[str, Any] | None:
+        """Return a flaky exit-status change, ignoring frequency-only noise."""
+        old_statuses = self._exit_statuses(old_project)
+        new_statuses = self._exit_statuses(new_project)
+        if not (
+            self._has_flaky_exit_evidence(old_project)
+            or self._has_flaky_exit_evidence(new_project)
+        ):
+            return None
+
+        old_codes = {status["return_code"] for status in old_statuses}
+        new_codes = {status["return_code"] for status in new_statuses}
+        old_panic_evidence = Counter(
+            (status["return_code"], key)
+            for status in old_statuses
+            for variant in status.get("panic_messages", [])
+            for key in index_panic_messages([variant["message"]])
+        )
+        new_panic_evidence = Counter(
+            (status["return_code"], key)
+            for status in new_statuses
+            for variant in status.get("panic_messages", [])
+            for key in index_panic_messages([variant["message"]])
+        )
+        old_stderr_evidence = {
+            (status["return_code"], variant["message"])
+            for status in old_statuses
+            for variant in status.get("stderr", [])
+        }
+        new_stderr_evidence = {
+            (status["return_code"], variant["message"])
+            for status in new_statuses
+            for variant in status.get("stderr", [])
+        }
+        # Frequencies from a finite sample of an already-flaky project are
+        # themselves noisy. Only a change in the observed outcome set is
+        # reliable enough to surface as a flaky exit-status change. Panic
+        # identities and stderr variants are evidence, rather than frequencies,
+        # so preserve changes to those even when the return-code set is stable.
+        if (
+            old_codes == new_codes
+            and old_panic_evidence == new_panic_evidence
+            and old_stderr_evidence == new_stderr_evidence
+        ):
+            return None
+
+        return {
+            "old": old_statuses,
+            "new": new_statuses,
+            "old_runs": self._total_runs(old_project),
+            "new_runs": self._total_runs(new_project),
+        }
 
     def _compute_diffs(self) -> dict[str, Any]:
         """Compute differences between the old and new diagnostic data."""
@@ -359,6 +472,7 @@ class DiagnosticDiff:
             "removed_projects": [],
             "modified_projects": [],
             "failed_projects": [],
+            "flaky_exit_status_changes": [],
         }
 
         # Get project names from both files
@@ -371,19 +485,53 @@ class DiagnosticDiff:
             old_project = old_projects[project_name]
             new_project = new_projects[project_name]
 
-            old_failed, old_status = self._is_project_failed(old_project)
-            new_failed, new_status = self._is_project_failed(new_project)
+            old_status = self._project_status(old_project)
+            new_status = self._project_status(new_project)
+            old_failed = old_status in {
+                _ProjectStatus.TIMEOUT,
+                _ProjectStatus.ABNORMAL_EXIT,
+            }
+            new_failed = new_status in {
+                _ProjectStatus.TIMEOUT,
+                _ProjectStatus.ABNORMAL_EXIT,
+            }
 
-            old_panics = old_project.get("panic_messages", [])
-            new_panics = new_project.get("panic_messages", [])
+            flaky_exit_status_change = self._compare_flaky_exit_statuses(
+                old_project, new_project
+            )
+            if flaky_exit_status_change:
+                result["flaky_exit_status_changes"].append({
+                    "project": project_name,
+                    "project_location": new_project.get("project_location", ""),
+                    **flaky_exit_status_change,
+                })
 
-            if old_failed or new_failed:
+            old_panics = self._stable_panic_messages(old_project)
+            new_panics = self._stable_panic_messages(new_project)
+
+            failure_transition_is_flaky = _ProjectStatus.FLAKY in {
+                old_status,
+                new_status,
+            }
+            if not failure_transition_is_flaky and (old_failed or new_failed):
                 introduced_panics, fixed_panics, persistent_panics = (
                     _compare_panic_messages(old_panics, new_panics)
                 )
                 abnormal_exit_kind_changed = (
-                    old_status == new_status == "abnormal exit"
-                    and old_project.get("return_code") != new_project.get("return_code")
+                    old_status is _ProjectStatus.ABNORMAL_EXIT
+                    and new_status is _ProjectStatus.ABNORMAL_EXIT
+                    and {
+                        status["return_code"]
+                        for status in self._exit_statuses(old_project)
+                    }
+                    != {
+                        status["return_code"]
+                        for status in self._exit_statuses(new_project)
+                    }
+                )
+                failure_mode_is_flaky = bool(
+                    len(self._exit_statuses(old_project)) > 1
+                    or len(self._exit_statuses(new_project)) > 1
                 )
 
                 # `failure_status` celebrates or flags overall state
@@ -401,9 +549,11 @@ class DiagnosticDiff:
                     failure_status = "fixed"
                 elif introduced_panics:
                     failure_status = "new_panics"
-                elif old_status != new_status or abnormal_exit_kind_changed:
+                elif not failure_mode_is_flaky and (
+                    old_status != new_status or abnormal_exit_kind_changed
+                ):
                     failure_status = "changed"
-                elif fixed_panics:
+                elif fixed_panics and flaky_exit_status_change is None:
                     failure_status = "reduced"
                 else:
                     failure_status = "persistent"
@@ -411,12 +561,12 @@ class DiagnosticDiff:
                 entry = {
                     "project": project_name,
                     "project_location": new_project.get("project_location", ""),
-                    "old_status": old_status,
-                    "new_status": new_status,
-                    "old_return_code": old_project.get("return_code"),
-                    "new_return_code": new_project.get("return_code"),
-                    "old_stderr": old_project.get("stderr"),
-                    "new_stderr": new_project.get("stderr"),
+                    "old_status": old_status.value,
+                    "new_status": new_status.value,
+                    "old_exit_statuses": self._exit_statuses(old_project),
+                    "new_exit_statuses": self._exit_statuses(new_project),
+                    "old_runs": self._total_runs(old_project),
+                    "new_runs": self._total_runs(new_project),
                     "old_panic_messages": old_panics,
                     "new_panic_messages": new_panics,
                     "introduced_panic_messages": introduced_panics,
@@ -453,6 +603,17 @@ class DiagnosticDiff:
                 if flaky:
                     entry["flaky_diagnostics"] = flaky
                     entry["flaky_runs"] = project_data.get("flaky_runs")
+                entry["exit_statuses"] = self._exit_statuses(project_data)
+                entry["exit_status_runs"] = self._total_runs(project_data)
+                if len(self._exit_statuses(project_data)) > 1:
+                    result["flaky_exit_status_changes"].append({
+                        "project": project_name,
+                        "project_location": project_data.get("project_location", ""),
+                        "old": self._exit_statuses(project_data),
+                        "new": [],
+                        "old_runs": self._total_runs(project_data),
+                        "new_runs": 0,
+                    })
                 result["removed_projects"].append(entry)
 
         # Find added projects
@@ -479,6 +640,17 @@ class DiagnosticDiff:
                 if flaky:
                     entry["flaky_diagnostics"] = flaky
                     entry["flaky_runs"] = project_data.get("flaky_runs")
+                entry["exit_statuses"] = self._exit_statuses(project_data)
+                entry["exit_status_runs"] = self._total_runs(project_data)
+                if len(self._exit_statuses(project_data)) > 1:
+                    result["flaky_exit_status_changes"].append({
+                        "project": project_name,
+                        "project_location": project_data.get("project_location", ""),
+                        "old": [],
+                        "new": self._exit_statuses(project_data),
+                        "old_runs": 0,
+                        "new_runs": self._total_runs(project_data),
+                    })
                 result["added_projects"].append(entry)
 
         # Get list of failed projects to exclude from detailed analysis
@@ -1026,20 +1198,11 @@ class DiagnosticDiff:
 
     def introduced_project_failures(self) -> list[str]:
         """Return project names that regressed from a normal exit to an abnormal exit or timeout."""
-        introduced: list[str] = []
-
-        for project in self.diffs.get("failed_projects", []):
-            old_return_code = project.get("old_return_code")
-            new_return_code = project.get("new_return_code")
-
-            if old_return_code not in (0, 1):
-                continue
-            if new_return_code in (0, 1):
-                continue
-
-            introduced.append(project["project"])
-
-        return introduced
+        return [
+            project["project"]
+            for project in self.diffs.get("failed_projects", [])
+            if project["failure_status"] == "new"
+        ]
 
     def has_new_panics(self) -> bool:
         """Check if any still-failing project gained panic messages."""
@@ -1090,8 +1253,10 @@ class DiagnosticDiff:
 
         return lines
 
-    def _has_flaky_diagnostics(self) -> bool:
-        """Check whether any flaky diagnostics were omitted from the raw diff."""
+    def _has_flaky_changes(self) -> bool:
+        """Check whether any flaky changes were omitted from the raw diff."""
+        if self.diffs.get("flaky_exit_status_changes"):
+            return True
         if any(
             project.get("flaky_diagnostics")
             for project in chain(
@@ -1145,8 +1310,10 @@ class DiagnosticDiff:
                 case "new":
                     line = (
                         f"- FAILED "
-                        f"old={project['old_status']}({project.get('old_return_code')}) "
-                        f"new={project['new_status']}({project.get('new_return_code')})"
+                        f"old={project['old_status']}"
+                        f"({self._format_exit_statuses(project['old_exit_statuses'])}) "
+                        f"new={project['new_status']}"
+                        f"({self._format_exit_statuses(project['new_exit_statuses'])})"
                     )
                 case "new_panics":
                     line = (
@@ -1156,14 +1323,18 @@ class DiagnosticDiff:
                 case "fixed":
                     line = (
                         f"+ FIXED "
-                        f"old={project['old_status']}({project.get('old_return_code')}) "
-                        f"new={project['new_status']}({project.get('new_return_code')})"
+                        f"old={project['old_status']}"
+                        f"({self._format_exit_statuses(project['old_exit_statuses'])}) "
+                        f"new={project['new_status']}"
+                        f"({self._format_exit_statuses(project['new_exit_statuses'])})"
                     )
                 case "changed":
                     line = (
                         f"  FAILURE MODE CHANGED "
-                        f"old={project['old_status']}({project.get('old_return_code')}) "
-                        f"new={project['new_status']}({project.get('new_return_code')})"
+                        f"old={project['old_status']}"
+                        f"({self._format_exit_statuses(project['old_exit_statuses'])}) "
+                        f"new={project['new_status']}"
+                        f"({self._format_exit_statuses(project['new_exit_statuses'])})"
                     )
                 case _:
                     line = (
@@ -1288,7 +1459,7 @@ class DiagnosticDiff:
             markdown_content += "**Failing projects**:\n\n"
             markdown_content += (
                 "| Project | Status | Old Status | New Status | "
-                "Old Return Code | New Return Code |\n"
+                "Old Outcomes | New Outcomes |\n"
             )
             markdown_content += (
                 "|---------|--------|------------|------------|"
@@ -1298,14 +1469,14 @@ class DiagnosticDiff:
             for project in table_projects:
                 old_status = project["old_status"]
                 new_status = project["new_status"]
-                old_rc = project.get("old_return_code", "None")
-                new_rc = project.get("new_return_code", "None")
+                old_outcomes = self._format_exit_statuses(project["old_exit_statuses"])
+                new_outcomes = self._format_exit_statuses(project["new_exit_statuses"])
                 status_label = _FAILURE_STATUS_LABELS[project["failure_status"]]
 
                 markdown_content += (
                     f"| `{project['project']}` | {status_label} | "
                     f"{old_status} | {new_status} | "
-                    f"`{old_rc}` | `{new_rc}` |\n"
+                    f"`{old_outcomes}` | `{new_outcomes}` |\n"
                 )
 
             markdown_content += "\n"
@@ -1354,7 +1525,7 @@ class DiagnosticDiff:
         raw_diff_sections, total_raw_diff_changes = self._raw_diff_sections()
         raw_diff_lines = self._render_raw_diff_sections(raw_diff_sections)
 
-        if self._has_flaky_diagnostics():
+        if self._has_flaky_changes():
             markdown_content += (
                 "\n\n_Flaky changes detected. "
                 "This PR summary excludes flaky changes; see the HTML report for details._"
@@ -1577,23 +1748,33 @@ class DiagnosticDiff:
             old_project = old_projects[project_name]
             new_project = new_projects[project_name]
 
-            # Get timing data and return codes
-            old_time = old_project.get("time_s")
-            new_time = new_project.get("time_s")
-            old_return_code = old_project.get("return_code")
-            new_return_code = new_project.get("return_code")
+            # A timing comparison cannot represent a project that only
+            # succeeds on some runs without turning a flaky exit into a
+            # misleading improvement or regression.
+            old_status = self._project_status(old_project)
+            new_status = self._project_status(new_project)
+            if _ProjectStatus.FLAKY in {
+                old_status,
+                new_status,
+            }:
+                continue
 
-            # Determine the status based on return codes and timing data
-            old_is_timeout = old_time is None
-            new_is_timeout = new_time is None
-            old_is_abnormal = old_return_code is not None and old_return_code not in (
-                0,
-                1,
-            )
-            new_is_abnormal = new_return_code is not None and new_return_code not in (
-                0,
-                1,
-            )
+            old_time = old_project.get("median_time_s")
+            new_time = new_project.get("median_time_s")
+
+            # Imported diagnostic output may have a known successful exit status
+            # without a measured runtime. It has no useful timing comparison.
+            if (
+                old_status is _ProjectStatus.SUCCESS
+                and new_status is _ProjectStatus.SUCCESS
+                and (old_time is None or new_time is None)
+            ):
+                continue
+
+            old_is_timeout = old_status is _ProjectStatus.TIMEOUT
+            new_is_timeout = new_status is _ProjectStatus.TIMEOUT
+            old_is_abnormal = old_status is _ProjectStatus.ABNORMAL_EXIT
+            new_is_abnormal = new_status is _ProjectStatus.ABNORMAL_EXIT
 
             # Handle different failure cases
             if (old_is_timeout or old_is_abnormal) and (
@@ -1629,8 +1810,6 @@ class DiagnosticDiff:
                 "project": project_name,
                 "old_time": old_time,
                 "new_time": new_time,
-                "old_return_code": old_return_code,
-                "new_return_code": new_return_code,
                 "factor": factor,
                 "is_failed": is_failed,
                 "failure_type": failure_type,

--- a/src/ecosystem_analyzer/main.py
+++ b/src/ecosystem_analyzer/main.py
@@ -11,6 +11,7 @@ from .diff import DiagnosticDiff
 from .ecosystem_report import generate
 from .git import get_latest_ty_commits, resolve_ty_repo
 from .manager import Manager, get_ecosystem_projects
+from .run_output import ExitStatus, OutputVariant
 
 logger = logging.getLogger(__name__)
 
@@ -698,18 +699,24 @@ def generate_report(
     help="Commit hash for GitHub links",
     type=str,
 )
+@click.option(
+    "--return-code",
+    type=int,
+    required=True,
+    help="Exit code from the ty process that produced the diagnostic output",
+)
 def parse_diagnostics(
-    output: str, project_name: str, project_location: str | None, commit: str | None
+    output: str,
+    project_name: str,
+    project_location: str | None,
+    commit: str | None,
+    return_code: int,
 ) -> None:
     """
     Parse ty diagnostic output from stdin and generate a JSON file.
     """
     # Read diagnostic output from stdin
     diagnostic_content = sys.stdin.read()
-
-    if not diagnostic_content.strip():
-        click.echo("No diagnostic content provided on stdin", err=True)
-        return
 
     # Create a parser with the provided information
     parser = DiagnosticsParser(
@@ -718,13 +725,23 @@ def parse_diagnostics(
         repo_working_dir=Path.cwd(),
     )
 
-    # Parse the diagnostics (parser will conditionally include github_ref)
+    # Parse diagnostics and panic output (the parser conditionally includes
+    # github_ref for regular diagnostics).
     diagnostics = parser.parse(diagnostic_content)
+    panic_messages = parser.parse_panic_messages(diagnostic_content)
+
+    exit_status = ExitStatus(return_code=return_code, count=1)
+    if panic_messages:
+        exit_status["panic_messages"] = [
+            OutputVariant(message=message, count=1) for message in panic_messages
+        ]
 
     # Create output structure - only include fields that have meaningful values
     run_output = {
         "project": project_name,
         "diagnostics": diagnostics,
+        "exit_statuses": [exit_status],
+        "median_time_s": None,
     }
 
     # Only include optional fields if they're provided

--- a/src/ecosystem_analyzer/run_output.py
+++ b/src/ecosystem_analyzer/run_output.py
@@ -23,15 +23,29 @@ class FlakyLocation(TypedDict):
     variants: list[FlakyVariant]
 
 
+class OutputVariant(TypedDict):
+    """Output text seen in some or all runs, with its frequency."""
+
+    message: str
+    count: int
+
+
+class ExitStatus(TypedDict):
+    """An exit status observed across one or more runs."""
+
+    return_code: int | None
+    count: int
+    panic_messages: NotRequired[list[OutputVariant]]
+    stderr: NotRequired[list[OutputVariant]]
+
+
 class RunOutput(TypedDict):
     project: str
     project_location: str
     ty_commit: str
     diagnostics: list[Diagnostic]
     flaky_diagnostics: NotRequired[list[FlakyLocation]]
+    exit_statuses: list[ExitStatus]
     flaky_runs: NotRequired[int]  # Total number of runs used for flaky detection
-    time_s: float | None
-    return_code: int | None
-    stderr: NotRequired[str]
-    panic_messages: NotRequired[list[str]]
+    median_time_s: float | None
     project_metadata: NotRequired[ProjectMetadata]

--- a/src/ecosystem_analyzer/templates/diff.html
+++ b/src/ecosystem_analyzer/templates/diff.html
@@ -634,6 +634,33 @@
 </div>
 {% endmacro %}
 
+{% macro render_exit_statuses(statuses, runs) %}
+{% if not statuses %}
+<span style="color: #6c757d;">not present</span>
+{% endif %}
+{% for status in statuses %}
+<div><span class="flaky-freq">({{ status.count }}/{{ runs }})</span>
+    {% if status.return_code is none %}
+    timeout
+    {% else %}
+    exit code <code>{{ status.return_code }}</code>
+    {% endif %}
+</div>
+{% for variant in status.get("panic_messages", []) %}
+<details class="failure-output-block panic-block-neutral">
+    <summary>panic ({{ variant.count }}/{{ runs }} runs)</summary>
+    <pre>{{ variant.message | e }}</pre>
+</details>
+{% endfor %}
+{% for variant in status.get("stderr", []) %}
+<details class="failure-output-block">
+    <summary>stderr ({{ variant.count }}/{{ runs }} runs)</summary>
+    <pre>{{ variant.message | e }}</pre>
+</details>
+{% endfor %}
+{% endfor %}
+{% endmacro %}
+
 <body>
     <div class="container">
         <div class="statistics">
@@ -793,8 +820,8 @@
                         <th style="padding: 12px; text-align: center;">Status</th>
                         <th style="padding: 12px; text-align: center;">Old Status</th>
                         <th style="padding: 12px; text-align: center;">New Status</th>
-                        <th style="padding: 12px; text-align: center;">Old Return Code</th>
-                        <th style="padding: 12px; text-align: center;">New Return Code</th>
+                        <th style="padding: 12px; text-align: center;">Old Outcomes</th>
+                        <th style="padding: 12px; text-align: center;">New Outcomes</th>
                     </tr>
                 </thead>
                 <tbody>
@@ -827,21 +854,13 @@
                             {% endif %}
                         </td>
                         <td style="padding: 12px; text-align: center; font-family: 'Fira Code', monospace;">
-                            {% if project.old_return_code is none %}
-                                <span style="color: #6c757d;">None</span>
-                            {% else %}
-                                {{ project.old_return_code }}
-                            {% endif %}
+                            {{ render_exit_statuses(project.old_exit_statuses, project.old_runs) }}
                         </td>
                         <td style="padding: 12px; text-align: center; font-family: 'Fira Code', monospace;">
-                            {% if project.new_return_code is none %}
-                                <span style="color: #6c757d;">None</span>
-                            {% else %}
-                                {{ project.new_return_code }}
-                            {% endif %}
+                            {{ render_exit_statuses(project.new_exit_statuses, project.new_runs) }}
                         </td>
                     </tr>
-                    {% if project.old_panic_messages or project.new_panic_messages or project.old_stderr or project.new_stderr %}
+                    {% if project.old_panic_messages or project.new_panic_messages %}
                     <tr class="failed-row-{{ failure_status }}" style="border-bottom: 1px solid rgba(38, 18, 48, 0.1);">
                         <td colspan="6" style="padding: 12px;">
                             {% if project.introduced_panic_messages %}
@@ -863,21 +882,37 @@
                                 <pre>{{ project.persistent_panic_messages | join('\n') | e }}</pre>
                             </details>
                             {% endif %}
-                            {% if project.old_stderr %}
-                            <details class="failure-output-block">
-                                <summary>Baseline stderr</summary>
-                                <pre>{{ project.old_stderr | e }}</pre>
-                            </details>
-                            {% endif %}
-                            {% if project.new_stderr %}
-                            <details class="failure-output-block">
-                                <summary>PR stderr</summary>
-                                <pre>{{ project.new_stderr | e }}</pre>
-                            </details>
-                            {% endif %}
                         </td>
                     </tr>
                     {% endif %}
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+        {% endif %}
+
+        {% if diffs.flaky_exit_status_changes %}
+        <h2>Flaky Exit Status Changes</h2>
+        <div class="failed-projects">
+            <table style="width: 100%; border-collapse: collapse; margin-bottom: 20px;">
+                <thead>
+                    <tr style="background: var(--flare); color: white;">
+                        <th style="padding: 12px; text-align: left;">Project</th>
+                        <th style="padding: 12px; text-align: left;">Baseline outcomes</th>
+                        <th style="padding: 12px; text-align: left;">PR outcomes</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for project in diffs.flaky_exit_status_changes %}
+                    <tr style="border-bottom: 1px solid rgba(38, 18, 48, 0.1);">
+                        <td style="padding: 12px;">
+                            <strong>{{ project.project }}</strong>
+                            <span class="flaky-badge" title="Exit status varied across repeated runs">flaky</span>
+                            <br><small><a href="{{ project.project_location }}" target="_blank">{{ project.project_location }}</a></small>
+                        </td>
+                        <td style="padding: 12px;">{{ render_exit_statuses(project.old, project.old_runs) }}</td>
+                        <td style="padding: 12px;">{{ render_exit_statuses(project.new, project.new_runs) }}</td>
+                    </tr>
                     {% endfor %}
                 </tbody>
             </table>
@@ -889,6 +924,7 @@
         {% for project in diffs.added_projects %}
         <div class="project added"{% if project.project_metadata is defined and project.project_metadata.kind is defined %} data-project-kind="{{ project.project_metadata.kind }}"{% endif %}>
             <h3>{{ project.project }} <small>(<a href="{{ project.project_location }}" target="_blank">{{ project.project_location }}</a>)</small></h3>
+            <div style="margin-bottom: 12px;"><strong>Observed outcomes:</strong> {{ render_exit_statuses(project.exit_statuses, project.exit_status_runs) }}</div>
             {% set file_groups = project.diagnostics|groupby('path') %}
             {% for path, diagnostics in file_groups %}
             <div class="file">
@@ -910,6 +946,7 @@
         {% for project in diffs.removed_projects %}
         <div class="project removed"{% if project.project_metadata is defined and project.project_metadata.kind is defined %} data-project-kind="{{ project.project_metadata.kind }}"{% endif %}>
             <h3>{{ project.project }} <small>(<a href="{{ project.project_location }}" target="_blank">{{ project.project_location }}</a>)</small></h3>
+            <div style="margin-bottom: 12px;"><strong>Observed outcomes:</strong> {{ render_exit_statuses(project.exit_statuses, project.exit_status_runs) }}</div>
             {% set file_groups = project.diagnostics|groupby('path') %}
             {% for path, diagnostics in file_groups %}
             <div class="file">

--- a/src/ecosystem_analyzer/ty.py
+++ b/src/ecosystem_analyzer/ty.py
@@ -9,10 +9,10 @@ from pathlib import Path
 
 from git import Commit, Repo
 
-from .diagnostic import DiagnosticsParser
+from .diagnostic import Diagnostic, DiagnosticsParser, index_panic_messages
 from .flaky import classify_diagnostics
 from .installed_project import InstalledProject
-from .run_output import RunOutput
+from .run_output import ExitStatus, OutputVariant, RunOutput
 
 logger = logging.getLogger(__name__)
 
@@ -20,6 +20,44 @@ logger = logging.getLogger(__name__)
 def _normalize_stderr(stderr: str) -> str | None:
     stderr = stderr.strip()
     return stderr or None
+
+
+def _aggregate_panic_messages(statuses: list[ExitStatus]) -> list[OutputVariant]:
+    """Aggregate normalized panic identities while preserving multiplicity."""
+    indexed_by_run = []
+    for status in statuses:
+        messages = [
+            variant["message"]
+            for variant in status.get("panic_messages", [])
+            for _ in range(variant["count"])
+        ]
+        indexed_by_run.append(index_panic_messages(messages))
+
+    variants = []
+    all_keys = set().union(*(indexed.keys() for indexed in indexed_by_run))
+    for key in all_keys:
+        messages_by_run = [indexed.get(key, []) for indexed in indexed_by_run]
+        max_multiplicity = max(map(len, messages_by_run))
+        for index in range(max_multiplicity):
+            present_messages = [
+                messages[index] for messages in messages_by_run if len(messages) > index
+            ]
+            variants.append(
+                OutputVariant(message=present_messages[0], count=len(present_messages))
+            )
+
+    return sorted(variants, key=lambda variant: variant["message"])
+
+
+def _aggregate_stderr(statuses: list[ExitStatus]) -> list[OutputVariant]:
+    """Aggregate exact stderr variants across runs with one count per run."""
+    counts: Counter[str] = Counter()
+    for status in statuses:
+        counts.update({variant["message"] for variant in status.get("stderr", [])})
+    return [
+        OutputVariant(message=message, count=count)
+        for message, count in sorted(counts.items())
+    ]
 
 
 class Ty:
@@ -155,60 +193,53 @@ class Ty:
             stderr = None
             panic_messages = []
 
-        output = RunOutput({
+        exit_status = ExitStatus(return_code=return_code, count=1)
+        if panic_messages:
+            exit_status["panic_messages"] = [
+                OutputVariant(message=message, count=1) for message in panic_messages
+            ]
+        if stderr:
+            exit_status["stderr"] = [OutputVariant(message=stderr, count=1)]
+
+        return RunOutput({
             "project": project.name,
             "project_location": project.location,
             "ty_commit": self.commit_sha,
             "diagnostics": diagnostics,
-            "time_s": execution_time,
-            "return_code": return_code,
+            "exit_statuses": [exit_status],
+            "median_time_s": execution_time,
         })
-        if stderr:
-            output["stderr"] = stderr
-        if panic_messages:
-            output["panic_messages"] = panic_messages
-        return output
 
     def run_on_project_multiple(self, project: InstalledProject, n: int) -> RunOutput:
-        """Run ty on a project N times and classify diagnostics as stable/flaky.
+        """Run ty on a project N times and classify diagnostics and exit statuses.
 
         Returns a single RunOutput where `diagnostics` contains only stable
-        diagnostics and `flaky_diagnostics` contains grouped flaky ones.
+        diagnostics, while flaky diagnostics and exit statuses retain their
+        frequencies across the runs.
         """
         assert n >= 2, "Use run_on_project for single runs"
         logger.info(
             f"Running ty on project '{project.name}' {n} times for flaky detection"
         )
 
-        all_diagnostics: list[list] = []
+        all_diagnostics: list[list[Diagnostic]] = []
         times: list[float] = []
-        return_codes: list[int | None] = []
+        statuses_by_return_code: dict[int | None, list[ExitStatus]] = {}
 
         for i in range(n):
             logger.info(f"  Run {i + 1}/{n} for '{project.name}'")
             output = self.run_on_project(project)
 
-            # If any run fails abnormally, bail out and return the failure
-            if output.get("return_code") is not None and output["return_code"] not in (
-                0,
-                1,
-            ):
-                logger.warning(
-                    f"Run {i + 1}/{n} for '{project.name}' failed with return code "
-                    f"{output['return_code']}; aborting flaky detection"
-                )
-                return output
-            if output.get("return_code") is None:
-                # Timeout
-                logger.warning(
-                    f"Run {i + 1}/{n} for '{project.name}' timed out; aborting flaky detection"
-                )
-                return output
-
             all_diagnostics.append(output["diagnostics"])
-            if (time_s := output.get("time_s")) is not None:
+            [exit_status] = output["exit_statuses"]
+            return_code = exit_status["return_code"]
+            statuses_by_return_code.setdefault(return_code, []).append(exit_status)
+
+            if (
+                return_code in (0, 1)
+                and (time_s := output.get("median_time_s")) is not None
+            ):
                 times.append(time_s)
-            return_codes.append(output.get("return_code"))
 
         stable, flaky_locations = classify_diagnostics(all_diagnostics)
 
@@ -219,9 +250,17 @@ class Ty:
             mid = len(sorted_times) // 2
             median_time = sorted_times[mid]
 
-        # Use most common return code
-        rc_counts = Counter(rc for rc in return_codes if rc is not None)
-        most_common_rc = rc_counts.most_common(1)[0][0] if rc_counts else None
+        exit_statuses = []
+        for return_code, statuses in sorted(
+            statuses_by_return_code.items(),
+            key=lambda item: (item[0] is None, item[0] or 0),
+        ):
+            exit_status = ExitStatus(return_code=return_code, count=len(statuses))
+            if panic_messages := _aggregate_panic_messages(statuses):
+                exit_status["panic_messages"] = panic_messages
+            if stderr := _aggregate_stderr(statuses):
+                exit_status["stderr"] = stderr
+            exit_statuses.append(exit_status)
 
         result = RunOutput({
             "project": project.name,
@@ -229,8 +268,8 @@ class Ty:
             "ty_commit": self.commit_sha,
             "diagnostics": stable,
             "flaky_runs": n,
-            "time_s": median_time,
-            "return_code": most_common_rc,
+            "exit_statuses": exit_statuses,
+            "median_time_s": median_time,
         })
 
         if flaky_locations:
@@ -240,6 +279,7 @@ class Ty:
         logger.info(
             f"  '{project.name}': {len(stable)} stable diagnostics, "
             f"{flaky_count} flaky diagnostics at {len(flaky_locations)} locations"
+            f", {len(exit_statuses)} exit status{'es' if len(exit_statuses) != 1 else ''}"
             f" ({n} runs)"
         )
 

--- a/tests/test_json_roundtrip.py
+++ b/tests/test_json_roundtrip.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from typing import Any
 
 from ecosystem_analyzer.diff import DiagnosticDiff
+from ecosystem_analyzer.run_output import ExitStatus, OutputVariant
 
 
 def _make_output(
@@ -11,28 +12,37 @@ def _make_output(
     diagnostics: list,
     flaky_diagnostics: list | None = None,
     flaky_runs: int | None = None,
+    exit_statuses: list | None = None,
     panic_messages: list[str] | None = None,
     stderr: str | None = None,
     time_s: float | None = 1.5,
     return_code: int | None = 1,
     project_metadata: dict | None = None,
 ):
+    run_count = flaky_runs or 1
+    if exit_statuses is None:
+        exit_status = ExitStatus(return_code=return_code, count=run_count)
+        if panic_messages is not None:
+            exit_status["panic_messages"] = [
+                OutputVariant(message=message, count=run_count)
+                for message in panic_messages
+            ]
+        if stderr is not None:
+            exit_status["stderr"] = [OutputVariant(message=stderr, count=run_count)]
+        exit_statuses = [exit_status]
+
     entry: dict[str, Any] = {
         "project": project,
         "project_location": f"https://github.com/example/{project}",
         "ty_commit": "abc123def456",
         "diagnostics": diagnostics,
-        "time_s": time_s,
-        "return_code": return_code,
+        "exit_statuses": exit_statuses,
+        "median_time_s": time_s,
     }
     if flaky_diagnostics is not None:
         entry["flaky_diagnostics"] = flaky_diagnostics
     if flaky_runs is not None:
         entry["flaky_runs"] = flaky_runs
-    if panic_messages is not None:
-        entry["panic_messages"] = panic_messages
-    if stderr is not None:
-        entry["stderr"] = stderr
     if project_metadata is not None:
         entry["project_metadata"] = project_metadata
     return entry
@@ -436,16 +446,16 @@ class TestJsonRoundtrip:
         assert "❌ newly failing" not in markdown
         assert "🎉" not in markdown
         assert (
-            "  FAILURE MODE CHANGED old=abnormal exit(101) new=timeout(None)"
-            in markdown
+            "  FAILURE MODE CHANGED old=abnormal exit(exit 101) "
+            "new=timeout(timeout)" in markdown
         )
         assert (
-            "  FAILURE MODE CHANGED old=timeout(None) new=abnormal exit(101)"
-            in markdown
+            "  FAILURE MODE CHANGED old=timeout(timeout) "
+            "new=abnormal exit(exit 101)" in markdown
         )
         assert (
-            "  FAILURE MODE CHANGED old=abnormal exit(101) "
-            "new=abnormal exit(139)" in markdown
+            "  FAILURE MODE CHANGED old=abnormal exit(exit 101) "
+            "new=abnormal exit(exit 139)" in markdown
         )
         assert "PARTIAL FIX" not in markdown
 
@@ -566,8 +576,6 @@ class TestJsonRoundtrip:
         entry = diff.diffs["failed_projects"][0]
 
         assert entry["failure_status"] == "persistent"
-        assert entry["old_stderr"] == old_stderr
-        assert entry["new_stderr"] == new_stderr
 
         markdown = diff.render_statistics_markdown()
         assert "same-code-error" not in markdown
@@ -576,8 +584,7 @@ class TestJsonRoundtrip:
 
         html = _render_html(diff)
         assert "same-code-error" in html
-        assert "<summary>Baseline stderr</summary>" in html
-        assert "<summary>PR stderr</summary>" in html
+        assert html.count("<summary>stderr (1/1 runs)</summary>") == 2
         assert "invalid invocation: &lt;old option&gt;" in html
         assert "invalid invocation: &lt;new option&gt;" in html
 
@@ -705,6 +712,371 @@ info: Args: /tmp/new_commit/ty check ."""
         )
 
         assert diff.introduced_project_failures() == ["proj"]
+
+    def test_intermittent_abnormal_exit_is_excluded_as_flaky(self):
+        diff = _make_diff(
+            [_make_output("proj", [], flaky_runs=3, return_code=1)],
+            [
+                _make_output(
+                    "proj",
+                    [],
+                    flaky_runs=3,
+                    exit_statuses=[
+                        {"return_code": 1, "count": 1},
+                        {
+                            "return_code": 2,
+                            "count": 2,
+                            "panic_messages": [
+                                {"message": "intermittent <panic>", "count": 2}
+                            ],
+                            "stderr": [
+                                {"message": "intermittent <stderr>", "count": 1}
+                            ],
+                        },
+                    ],
+                    return_code=1,
+                )
+            ],
+        )
+
+        assert diff.diffs["failed_projects"] == []
+        assert diff.introduced_project_failures() == []
+        assert len(diff.diffs["flaky_exit_status_changes"]) == 1
+        assert diff.generate_comment_title() == "## `ecosystem-analyzer` results"
+
+        markdown = diff.render_statistics_markdown()
+        assert "excludes flaky changes" in markdown
+        assert "new crashes detected" not in markdown
+
+        html = _render_html(diff)
+        assert "Flaky Exit Status Changes" in html
+        assert "(2/3)" in html
+        assert "exit code <code>2</code>" in html
+        assert "panic (2/3 runs)" in html
+        assert "intermittent &lt;panic&gt;" in html
+        assert "stderr (1/3 runs)" in html
+        assert "intermittent &lt;stderr&gt;" in html
+
+    def test_intermittent_timeout_is_excluded_as_flaky(self):
+        diff = _make_diff(
+            [_make_output("proj", [], flaky_runs=3, return_code=1)],
+            [
+                _make_output(
+                    "proj",
+                    [],
+                    flaky_runs=3,
+                    exit_statuses=[
+                        {"return_code": 1, "count": 2},
+                        {"return_code": None, "count": 1},
+                    ],
+                    return_code=1,
+                )
+            ],
+        )
+
+        assert diff.diffs["failed_projects"] == []
+        assert diff.introduced_project_failures() == []
+        assert "timeout" in _render_html(diff)
+
+    def test_stable_failure_to_intermittent_success_is_not_fixed(self):
+        diff = _make_diff(
+            [_make_failed_output("proj", return_code=2)],
+            [
+                _make_output(
+                    "proj",
+                    [],
+                    flaky_runs=3,
+                    exit_statuses=[
+                        {"return_code": 1, "count": 1},
+                        {"return_code": 2, "count": 2},
+                    ],
+                    return_code=1,
+                )
+            ],
+        )
+
+        assert diff.diffs["failed_projects"] == []
+        assert "ecosystem failure fixed" not in diff.generate_comment_title()
+        assert len(diff.diffs["flaky_exit_status_changes"]) == 1
+
+    def test_intermittent_failure_to_stable_failure_is_not_new(self):
+        diff = _make_diff(
+            [
+                _make_output(
+                    "proj",
+                    [],
+                    flaky_runs=3,
+                    exit_statuses=[
+                        {"return_code": 1, "count": 2},
+                        {"return_code": 2, "count": 1},
+                    ],
+                    return_code=1,
+                )
+            ],
+            [_make_failed_output("proj", return_code=2)],
+        )
+
+        assert diff.diffs["failed_projects"] == []
+        assert diff.introduced_project_failures() == []
+        assert len(diff.diffs["flaky_exit_status_changes"]) == 1
+
+    def test_varying_abnormal_exit_codes_still_form_stable_failure(self):
+        diff = _make_diff(
+            [_make_output("proj", [], flaky_runs=3, return_code=1)],
+            [
+                _make_output(
+                    "proj",
+                    [],
+                    flaky_runs=3,
+                    exit_statuses=[
+                        {"return_code": 2, "count": 2},
+                        {"return_code": 3, "count": 1},
+                    ],
+                    time_s=None,
+                    return_code=2,
+                )
+            ],
+        )
+
+        assert diff.introduced_project_failures() == ["proj"]
+        assert diff.diffs["failed_projects"][0]["failure_status"] == "new"
+
+    def test_varying_failure_codes_on_both_sides_are_persistent(self):
+        old_statuses = [
+            {"return_code": 2, "count": 2},
+            {"return_code": 3, "count": 1},
+        ]
+        new_statuses = [
+            {"return_code": 2, "count": 1},
+            {"return_code": 3, "count": 2},
+        ]
+        diff = _make_diff(
+            [
+                _make_output(
+                    "proj",
+                    [],
+                    flaky_runs=3,
+                    exit_statuses=old_statuses,
+                    time_s=None,
+                    return_code=2,
+                )
+            ],
+            [
+                _make_output(
+                    "proj",
+                    [],
+                    flaky_runs=3,
+                    exit_statuses=new_statuses,
+                    time_s=None,
+                    return_code=3,
+                )
+            ],
+        )
+
+        assert diff.diffs["flaky_exit_status_changes"] == []
+        assert diff.diffs["failed_projects"][0]["failure_status"] == "persistent"
+
+    def test_stable_diagnostic_changes_survive_flaky_exit_status(self):
+        old_diagnostic = {
+            "level": "error",
+            "lint_name": "some-lint",
+            "path": "a.py",
+            "line": 1,
+            "column": 1,
+            "message": "old",
+        }
+        new_diagnostic = {
+            **old_diagnostic,
+            "line": 2,
+            "message": "new stable diagnostic",
+        }
+        diff = _make_diff(
+            [_make_output("proj", [old_diagnostic], flaky_runs=3, return_code=1)],
+            [
+                _make_output(
+                    "proj",
+                    [old_diagnostic, new_diagnostic],
+                    flaky_runs=3,
+                    exit_statuses=[
+                        {"return_code": 1, "count": 2},
+                        {"return_code": 2, "count": 1},
+                    ],
+                    return_code=1,
+                )
+            ],
+        )
+
+        assert diff._calculate_statistics()["total_added"] == 1
+
+    def test_added_project_preserves_flaky_exit_status_evidence(self):
+        output = _make_output(
+            "new-project",
+            [],
+            flaky_runs=3,
+            exit_statuses=[
+                {"return_code": 1, "count": 2},
+                {
+                    "return_code": 2,
+                    "count": 1,
+                    "stderr": [{"message": "new project crashed", "count": 1}],
+                },
+            ],
+        )
+        diff = _make_diff([], [output])
+
+        assert len(diff.diffs["flaky_exit_status_changes"]) == 1
+        assert "excludes flaky changes" in diff.render_statistics_markdown()
+        html = _render_html(diff)
+        assert "Flaky Exit Status Changes" in html
+        assert "new project crashed" in html
+        assert "not present" in html
+
+    def test_removed_project_preserves_flaky_exit_status_evidence(self):
+        output = _make_output(
+            "old-project",
+            [],
+            flaky_runs=3,
+            exit_statuses=[
+                {"return_code": 1, "count": 2},
+                {
+                    "return_code": None,
+                    "count": 1,
+                    "stderr": [{"message": "old project timed out", "count": 1}],
+                },
+            ],
+        )
+        diff = _make_diff([output], [])
+
+        assert len(diff.diffs["flaky_exit_status_changes"]) == 1
+        assert "excludes flaky changes" in diff.render_statistics_markdown()
+        html = _render_html(diff)
+        assert "Flaky Exit Status Changes" in html
+        assert "old project timed out" in html
+        assert "not present" in html
+
+    def test_flaky_exit_evidence_changes_with_same_statuses_are_preserved(self):
+        old_statuses = [
+            {"return_code": 1, "count": 2},
+            {
+                "return_code": 2,
+                "count": 1,
+                "panic_messages": [{"message": "old panic", "count": 1}],
+                "stderr": [{"message": "old stderr", "count": 1}],
+            },
+        ]
+        new_statuses = [
+            {"return_code": 1, "count": 2},
+            {
+                "return_code": 2,
+                "count": 1,
+                "panic_messages": [{"message": "new panic", "count": 1}],
+                "stderr": [{"message": "new stderr", "count": 1}],
+            },
+        ]
+        diff = _make_diff(
+            [_make_output("proj", [], flaky_runs=3, exit_statuses=old_statuses)],
+            [_make_output("proj", [], flaky_runs=3, exit_statuses=new_statuses)],
+        )
+
+        assert len(diff.diffs["flaky_exit_status_changes"]) == 1
+        html = _render_html(diff)
+        assert "old panic" in html
+        assert "new panic" in html
+        assert "old stderr" in html
+        assert "new stderr" in html
+
+    def test_intermittent_panic_change_with_one_exit_status_is_preserved(self):
+        old_statuses = [
+            {
+                "return_code": 101,
+                "count": 3,
+                "panic_messages": [{"message": "panic A", "count": 3}],
+            }
+        ]
+        new_statuses = [
+            {
+                "return_code": 101,
+                "count": 3,
+                "panic_messages": [
+                    {"message": "panic A", "count": 2},
+                    {"message": "panic B", "count": 1},
+                ],
+            }
+        ]
+        diff = _make_diff(
+            [
+                _make_output(
+                    "proj",
+                    [],
+                    flaky_runs=3,
+                    time_s=None,
+                    exit_statuses=old_statuses,
+                )
+            ],
+            [
+                _make_output(
+                    "proj",
+                    [],
+                    flaky_runs=3,
+                    time_s=None,
+                    exit_statuses=new_statuses,
+                )
+            ],
+        )
+
+        assert len(diff.diffs["flaky_exit_status_changes"]) == 1
+        assert diff.diffs["failed_projects"][0]["failure_status"] == "persistent"
+        assert "panics reduced" not in diff.generate_comment_title()
+        html = _render_html(diff)
+        assert "panic A" in html
+        assert "panic B" in html
+
+    def test_added_and_removed_projects_render_stable_exit_evidence(self):
+        added = _make_output(
+            "added",
+            [],
+            return_code=2,
+            panic_messages=["added panic"],
+            stderr="added stderr",
+        )
+        removed = _make_output(
+            "removed",
+            [],
+            return_code=2,
+            panic_messages=["removed panic"],
+            stderr="removed stderr",
+        )
+        diff = _make_diff([removed], [added])
+
+        assert (
+            diff.diffs["added_projects"][0]["exit_statuses"] == added["exit_statuses"]
+        )
+        assert (
+            diff.diffs["removed_projects"][0]["exit_statuses"]
+            == removed["exit_statuses"]
+        )
+        html = _render_html(diff)
+        assert "added panic" in html
+        assert "added stderr" in html
+        assert "removed panic" in html
+        assert "removed stderr" in html
+
+    def test_flaky_exit_frequency_changes_are_ignored(self):
+        old_statuses = [
+            {"return_code": 1, "count": 9},
+            {"return_code": 2, "count": 1},
+        ]
+        new_statuses = [
+            {"return_code": 1, "count": 1},
+            {"return_code": 2, "count": 9},
+        ]
+        diff = _make_diff(
+            [_make_output("proj", [], flaky_runs=10, exit_statuses=old_statuses)],
+            [_make_output("proj", [], flaky_runs=10, exit_statuses=new_statuses)],
+        )
+
+        assert diff.diffs["flaky_exit_status_changes"] == []
+        assert diff.diffs["failed_projects"] == []
 
     def test_comment_title_combines_panics_crashes_and_timeouts(self):
         diff = _make_diff(

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,121 @@
+import json
+
+from click.testing import CliRunner
+
+from ecosystem_analyzer.main import cli
+
+
+def test_parse_diagnostics_requires_return_code(tmp_path):
+    output = tmp_path / "diagnostics.json"
+
+    result = CliRunner().invoke(
+        cli,
+        ["parse-diagnostics", "--output", str(output)],
+        input="All checks passed!\n",
+    )
+
+    assert result.exit_code == 2
+    assert "Missing option '--return-code'" in result.output
+    assert not output.exists()
+
+
+def test_parse_diagnostics_preserves_exit_status_and_panic(tmp_path):
+    output = tmp_path / "diagnostics.json"
+    panic = """error[panic]: internal error
+info: Version: 0.0.1
+"""
+
+    result = CliRunner().invoke(
+        cli,
+        [
+            "parse-diagnostics",
+            "--output",
+            str(output),
+            "--return-code",
+            "101",
+        ],
+        input=panic,
+    )
+
+    assert result.exit_code == 0, result.output
+    [run_output] = json.loads(output.read_text())["outputs"]
+    assert run_output["diagnostics"] == []
+    assert run_output["exit_statuses"] == [
+        {
+            "return_code": 101,
+            "count": 1,
+            "panic_messages": [
+                {"message": "internal error\ninfo: Version: 0.0.1", "count": 1}
+            ],
+        }
+    ]
+
+
+def test_parse_diagnostics_preserves_empty_output_exit_status(tmp_path):
+    output = tmp_path / "diagnostics.json"
+
+    result = CliRunner().invoke(
+        cli,
+        [
+            "parse-diagnostics",
+            "--output",
+            str(output),
+            "--return-code",
+            "101",
+        ],
+        input="",
+    )
+
+    assert result.exit_code == 0, result.output
+    [run_output] = json.loads(output.read_text())["outputs"]
+    assert run_output["diagnostics"] == []
+    assert run_output["exit_statuses"] == [{"return_code": 101, "count": 1}]
+
+
+def test_statistics_skip_missing_timings_from_parsed_diagnostics(tmp_path):
+    runner = CliRunner()
+    old_output = tmp_path / "old.json"
+    new_output = tmp_path / "new.json"
+    statistics = tmp_path / "statistics.md"
+
+    result = runner.invoke(
+        cli,
+        [
+            "parse-diagnostics",
+            "--output",
+            str(old_output),
+            "--return-code",
+            "0",
+        ],
+        input="All checks passed!\n",
+    )
+    assert result.exit_code == 0, result.output
+
+    result = runner.invoke(
+        cli,
+        [
+            "parse-diagnostics",
+            "--output",
+            str(new_output),
+            "--return-code",
+            "1",
+        ],
+        input="example.py:1:1: error[invalid-assignment] Bad assignment\n",
+    )
+    assert result.exit_code == 0, result.output
+
+    result = runner.invoke(
+        cli,
+        [
+            "generate-diff-statistics",
+            str(old_output),
+            str(new_output),
+            "--output",
+            str(statistics),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    markdown = statistics.read_text()
+    assert "| `invalid-assignment` | 1 | 0 | 0 |" in markdown
+    assert "| **Total** | **1** | **0** | **0** |" in markdown

--- a/tests/test_ty.py
+++ b/tests/test_ty.py
@@ -1,0 +1,153 @@
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from ecosystem_analyzer.installed_project import InstalledProject
+from ecosystem_analyzer.run_output import ExitStatus, OutputVariant, RunOutput
+from ecosystem_analyzer.ty import Ty
+
+
+def _output(
+    return_code: int | None,
+    *,
+    diagnostics: list | None = None,
+    time_s: float | None = None,
+    panic_messages: list[str] | None = None,
+    stderr: str | None = None,
+) -> RunOutput:
+    exit_status = ExitStatus(return_code=return_code, count=1)
+    if panic_messages:
+        exit_status["panic_messages"] = [
+            OutputVariant(message=message, count=1) for message in panic_messages
+        ]
+    if stderr:
+        exit_status["stderr"] = [OutputVariant(message=stderr, count=1)]
+    output = RunOutput({
+        "project": "proj",
+        "project_location": "https://github.com/example/proj",
+        "ty_commit": "abc123",
+        "diagnostics": diagnostics or [],
+        "exit_statuses": [exit_status],
+        "median_time_s": time_s,
+    })
+    return output
+
+
+def _ty() -> Ty:
+    ty = Ty()
+    ty.use_prebuilt(Path("ty"), "abc123")
+    return ty
+
+
+def _project() -> InstalledProject:
+    project = MagicMock(spec=InstalledProject)
+    project.name = "proj"
+    project.location = "https://github.com/example/proj"
+    return project
+
+
+def test_multiple_runs_classify_intermittent_abnormal_exit_as_flaky():
+    diagnostic = {
+        "level": "error",
+        "lint_name": "some-lint",
+        "path": "a.py",
+        "line": 1,
+        "column": 1,
+        "message": "only emitted by successful runs",
+    }
+    outputs = [
+        _output(2, panic_messages=["intermittent panic"], stderr="crashed"),
+        _output(1, diagnostics=[diagnostic], time_s=1.0),
+        _output(1, diagnostics=[diagnostic], time_s=2.0),
+    ]
+    ty = _ty()
+
+    with patch.object(ty, "run_on_project", side_effect=outputs) as run:
+        result = ty.run_on_project_multiple(_project(), 3)
+
+    assert run.call_count == 3
+    assert result["exit_statuses"] == [
+        {"return_code": 1, "count": 2},
+        {
+            "return_code": 2,
+            "count": 1,
+            "panic_messages": [{"message": "intermittent panic", "count": 1}],
+            "stderr": [{"message": "crashed", "count": 1}],
+        },
+    ]
+    assert result["diagnostics"] == []
+    assert result["flaky_diagnostics"][0]["variants"][0]["count"] == 2
+    assert "return_code" not in result
+    assert "time_s" not in result
+    assert "panic_messages" not in result
+    assert "stderr" not in result
+
+
+def test_multiple_runs_classify_intermittent_timeout_as_flaky():
+    outputs = [
+        _output(1, time_s=1.0),
+        _output(None),
+        _output(1, time_s=2.0),
+    ]
+    ty = _ty()
+
+    with patch.object(ty, "run_on_project", side_effect=outputs) as run:
+        result = ty.run_on_project_multiple(_project(), 3)
+
+    assert run.call_count == 3
+    assert result["exit_statuses"] == [
+        {"return_code": 1, "count": 2},
+        {"return_code": None, "count": 1},
+    ]
+
+
+def test_multiple_runs_preserve_stable_abnormal_exit_evidence():
+    panic_messages = [
+        "Panicked at crates/ty_python_semantic/src/types/infer.rs:10:2: `bug`\n"
+        f"info: Version: 0.0.{version}"
+        for version in range(3)
+    ]
+    outputs = [
+        _output(2, panic_messages=[panic], stderr="stable stderr")
+        for panic in panic_messages
+    ]
+    ty = _ty()
+
+    with patch.object(ty, "run_on_project", side_effect=outputs):
+        result = ty.run_on_project_multiple(_project(), 3)
+
+    assert result["median_time_s"] is None
+    assert result["exit_statuses"] == [
+        {
+            "return_code": 2,
+            "count": 3,
+            "panic_messages": [{"message": panic_messages[0], "count": 3}],
+            "stderr": [{"message": "stable stderr", "count": 3}],
+        }
+    ]
+
+
+def test_multiple_runs_preserve_stable_timeout():
+    ty = _ty()
+
+    with patch.object(ty, "run_on_project", side_effect=[_output(None)] * 3):
+        result = ty.run_on_project_multiple(_project(), 3)
+
+    assert result["exit_statuses"] == [{"return_code": None, "count": 3}]
+    assert result["median_time_s"] is None
+
+
+def test_multiple_runs_preserve_mixed_status_frequencies():
+    outputs = [
+        _output(2),
+        _output(2),
+        _output(1, time_s=1.0),
+    ]
+    ty = _ty()
+
+    with patch.object(ty, "run_on_project", side_effect=outputs):
+        result = ty.run_on_project_multiple(_project(), 3)
+
+    assert result["exit_statuses"] == [
+        {"return_code": 1, "count": 1},
+        {"return_code": 2, "count": 2},
+    ]


### PR DESCRIPTION
There was a Ruff PR recently where steam.py showed up as "newly timing out". But in a rerun that disappeared. steam.py is in flaky.txt, so ecosystem-analyzer should have rerun the change before reporting it as a regression. But we currently only run flaky detection for diagnostic changes, not for changes in exit codes. This PR plugs that hole.

Below is codex's summary.

## Summary

- detect flaky changes in project exit outcomes, including timeouts and abnormal exit codes
- preserve per-outcome panic and stderr evidence across repeated runs
- exclude unreliable flaky exit changes from regression statistics while rendering them in the HTML report
- replace the old scalar run-result fields with explicit counted exit outcomes
- keep imported diagnostic output honest by requiring its actual return code and preserving panic evidence

## Behavior

Known-flaky projects now complete all configured runs and retain every observed outcome. A mixture of normal and abnormal exits is treated as flaky rather than as a reliable new failure or fix. Changes in observed outcomes and panic/stderr evidence are shown in a dedicated HTML section; frequency-only changes remain ignored as sampling noise.

The output schema now uses `exit_statuses` and `median_time_s` instead of the previous top-level `return_code`, `time_s`, `stderr`, and `panic_messages` fields.

## Screenshots

### Flaky timeout

![Flaky timeout report](https://raw.githubusercontent.com/astral-sh/ecosystem-analyzer/pr-assets-flaky-exit-status-detection/.github/pr-assets/flaky-exit-status-detection/flaky-timeout.png)

### Flaky panic

![Flaky panic report](https://raw.githubusercontent.com/astral-sh/ecosystem-analyzer/pr-assets-flaky-exit-status-detection/.github/pr-assets/flaky-exit-status-detection/flaky-panic.png)

