### PR TITLE
Avoid classifying stable stack overflows as flaky

### DIFF
--- a/src/ecosystem_analyzer/diagnostic.py
+++ b/src/ecosystem_analyzer/diagnostic.py
@@ -14,6 +14,9 @@ NEW_DIAGNOSTIC_PATTERN = re.compile(
 )
 PANIC_PATTERN = re.compile(r"^(?:error|fatal)\[panic\](?::)? (?P<message>.+)$")
 _RUST_SOURCE_LOCATION_PATTERN = re.compile(r"(?P<path>\S+\.rs):\d+(?::\d+)?")
+_STACK_OVERFLOW_THREAD_ID_PATTERN = re.compile(
+    r"(?m)^(thread .+?) \(\d+\)( has overflowed its stack)$"
+)
 _PANIC_TRACE_HEADERS = {"info: Backtrace:", "info: query stacktrace:"}
 _VOLATILE_PANIC_METADATA_PREFIXES = ("info: Version:", "info: Args:")
 
@@ -38,6 +41,11 @@ def index_panic_messages(messages: list[str]) -> dict[str, list[str]]:
         key = normalize_panic_message(message)
         indexed_messages.setdefault(key, []).append(message)
     return indexed_messages
+
+
+def normalize_stderr(message: str) -> str:
+    """Remove volatile details before comparing stderr output."""
+    return _STACK_OVERFLOW_THREAD_ID_PATTERN.sub(r"\1 (<thread-id>)\2", message)
 
 
 class Diagnostic(TypedDict):

--- a/src/ecosystem_analyzer/diff.py
+++ b/src/ecosystem_analyzer/diff.py
@@ -10,7 +10,7 @@ from typing import Any, Literal, TypedDict
 
 from jinja2 import Environment, FileSystemLoader, PackageLoader
 
-from .diagnostic import Diagnostic, index_panic_messages
+from .diagnostic import Diagnostic, index_panic_messages, normalize_stderr
 from .run_output import ExitStatus, OutputVariant, RunOutput
 
 
@@ -402,13 +402,20 @@ class DiagnosticDiff:
         statuses = self._exit_statuses(project_data)
         if len(statuses) > 1:
             return True
-        return any(
-            variant["count"] != status["count"]
-            for status in statuses
-            for variant in chain(
-                status.get("panic_messages", []), status.get("stderr", [])
-            )
-        )
+        for status in statuses:
+            if any(
+                variant["count"] != status["count"]
+                for variant in status.get("panic_messages", [])
+            ):
+                return True
+
+            stderr_counts: Counter[str] = Counter()
+            for variant in status.get("stderr", []):
+                stderr_counts[normalize_stderr(variant["message"])] += variant["count"]
+            if any(count != status["count"] for count in stderr_counts.values()):
+                return True
+
+        return False
 
     def _compare_flaky_exit_statuses(
         self, old_project: RunOutput, new_project: RunOutput
@@ -437,12 +444,12 @@ class DiagnosticDiff:
             for key in index_panic_messages([variant["message"]])
         )
         old_stderr_evidence = {
-            (status["return_code"], variant["message"])
+            (status["return_code"], normalize_stderr(variant["message"]))
             for status in old_statuses
             for variant in status.get("stderr", [])
         }
         new_stderr_evidence = {
-            (status["return_code"], variant["message"])
+            (status["return_code"], normalize_stderr(variant["message"]))
             for status in new_statuses
             for variant in status.get("stderr", [])
         }

--- a/tests/test_json_roundtrip.py
+++ b/tests/test_json_roundtrip.py
@@ -841,6 +841,42 @@ info: Args: /tmp/new_commit/ty check ."""
         assert diff.introduced_project_failures() == ["proj"]
         assert diff.diffs["failed_projects"][0]["failure_status"] == "new"
 
+    def test_stable_stack_overflow_with_varying_thread_ids_is_not_flaky(self):
+        stack_overflows = [
+            {
+                "message": (
+                    f"thread '<unknown>' ({thread_id}) has overflowed its stack\n"
+                    "fatal runtime error: stack overflow, aborting"
+                ),
+                "count": 1,
+            }
+            for thread_id in range(10)
+        ]
+        diff = _make_diff(
+            [_make_output("proj", [], flaky_runs=10, return_code=1)],
+            [
+                _make_output(
+                    "proj",
+                    [],
+                    flaky_runs=10,
+                    exit_statuses=[
+                        {
+                            "return_code": -6,
+                            "count": 10,
+                            "stderr": stack_overflows,
+                        }
+                    ],
+                    time_s=None,
+                )
+            ],
+        )
+
+        assert diff.diffs["flaky_exit_status_changes"] == []
+        assert diff.diffs["failed_projects"][0]["failure_status"] == "new"
+        html = _render_html(diff)
+        assert "Failed Projects" in html
+        assert "Flaky Exit Status Changes" not in html
+
     def test_varying_failure_codes_on_both_sides_are_persistent(self):
         old_statuses = [
             {"return_code": 2, "count": 2},


### PR DESCRIPTION
## Summary

Normalize volatile thread IDs in Rust stack-overflow stderr before comparing repeated runs.

Aggregate equivalent stderr variants when deciding whether an exit outcome is flaky, while preserving genuinely different stderr evidence.

Add regression coverage for a project that exits with the same stack overflow in all 10 runs but reports a different runtime thread ID each time.

## Motivation

The exit-status classifier previously compared raw stderr variants independently. Rust includes a numeric thread ID in its stack-overflow message, so ten otherwise-identical failures appeared as ten one-run stderr variants. This incorrectly put a consistently failing project in both the failed-projects table and the flaky-exit-status table.
