### PR TITLE
Fix mobile report table overflow

### DIFF
--- a/src/ecosystem_analyzer/templates/diff.html
+++ b/src/ecosystem_analyzer/templates/diff.html
@@ -395,6 +395,13 @@
             color: #dc3545;
         }
 
+        .stats-grid {
+            display: grid;
+            grid-template-columns: repeat(2, minmax(0, 1fr));
+            gap: 20px;
+            margin-top: 16px;
+        }
+
         .stats-table {
             font-family: 'Fira Code', monospace;
             font-size: 13px;
@@ -588,6 +595,32 @@
             background: rgba(99, 64, 172, 0.2);
             border-color: var(--flare);
         }
+
+        @media (max-width: 800px) {
+            body {
+                padding: 12px;
+            }
+
+            .statistics {
+                padding: 12px;
+            }
+
+            .stats-grid {
+                grid-template-columns: minmax(0, 1fr);
+            }
+
+            .stats-table {
+                width: 100%;
+                table-layout: fixed;
+            }
+
+            .stats-table th,
+            .stats-table td,
+            .stats-table .total-row td {
+                padding: 4px;
+                overflow-wrap: anywhere;
+            }
+        }
     </style>
 </head>
 
@@ -673,7 +706,7 @@
                 <a href="{{ ty_repo_url }}/commit/{{ new_commit }}" target="_blank" style="color: var(--flare); text-decoration: none;">{{ new_commit[:8] }}</a>
             </div>
             {% if statistics.merged_by_lint or statistics.merged_by_project %}
-            <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 20px; margin-top: 16px;">
+            <div class="stats-grid">
                 {% if statistics.merged_by_lint %}
                 <div>
                     <table class="stats-table">


### PR DESCRIPTION
## Summary

- make the statistics grid tracks shrink within the report card
- stack the lint and project tables on narrow screens
- reduce mobile spacing and wrap long table values so the report stays within the viewport

## Why

The statistics section always used two intrinsic-width grid columns. On narrow screens, the tables could not shrink enough, so the second table rendered beyond the rounded white report card. The responsive layout keeps the existing two-column desktop presentation while containing both tables on mobile.

## Screenshots

### Mobile

<img width="412" height="915" alt="Mobile report with contained statistics tables" src="https://github.com/user-attachments/assets/91f44a14-503e-4f7d-a551-46070fb46641" />

### Desktop

<img width="1280" height="720" alt="Desktop report with two-column statistics tables" src="https://github.com/user-attachments/assets/bde58ce1-79c1-4863-8f01-d11c8f6bbce3" />
