### PR TITLE
Avoid duplicating stable panic messages in HTML reports

### DIFF
--- a/src/ecosystem_analyzer/diff.py
+++ b/src/ecosystem_analyzer/diff.py
@@ -10,7 +10,11 @@ from typing import Any, Literal, TypedDict
 
 from jinja2 import Environment, FileSystemLoader, PackageLoader
 
-from .diagnostic import Diagnostic, index_panic_messages, normalize_stderr
+from .diagnostic import (
+    Diagnostic,
+    index_panic_messages,
+    normalize_stderr,
+)
 from .run_output import ExitStatus, OutputVariant, RunOutput
 
 
@@ -78,15 +82,16 @@ class _ProjectStatus(Enum):
     FLAKY = "flaky"
 
 
-def _compare_panic_messages(
+def _partition_panic_messages(
     old_messages: list[str], new_messages: list[str]
-) -> tuple[list[str], list[str], list[str]]:
-    """Return introduced, fixed, and persistent panic messages."""
+) -> tuple[list[str], list[str], list[str], list[str]]:
+    """Return introduced, fixed, old-persistent, and new-persistent messages."""
     old_messages_by_key = index_panic_messages(old_messages)
     new_messages_by_key = index_panic_messages(new_messages)
     introduced = []
     fixed = []
-    persistent = []
+    old_persistent = []
+    new_persistent = []
 
     for key in old_messages_by_key.keys() | new_messages_by_key.keys():
         old_counts = Counter(old_messages_by_key.get(key, []))
@@ -95,16 +100,23 @@ def _compare_panic_messages(
         # Match unchanged raw messages first so any count delta reports the
         # most likely added or removed panic site.
         exact_matches = old_counts & new_counts
+        old_persistent.extend(exact_matches.elements())
+        new_persistent.extend(exact_matches.elements())
         unmatched_old = list((old_counts - exact_matches).elements())
         unmatched_new = list((new_counts - exact_matches).elements())
-        persistent.extend(exact_matches.elements())
 
         persistent_count = min(len(unmatched_old), len(unmatched_new))
-        persistent.extend(unmatched_new[:persistent_count])
+        old_persistent.extend(unmatched_old[:persistent_count])
+        new_persistent.extend(unmatched_new[:persistent_count])
         fixed.extend(unmatched_old[persistent_count:])
         introduced.extend(unmatched_new[persistent_count:])
 
-    return sorted(introduced), sorted(fixed), sorted(persistent)
+    return (
+        sorted(introduced),
+        sorted(fixed),
+        sorted(old_persistent),
+        sorted(new_persistent),
+    )
 
 
 def _failure_descriptor(
@@ -369,10 +381,11 @@ class DiagnosticDiff:
             )
             representatives = [
                 variant["message"]
-                for variants in variants_by_status
+                for status, variants in zip(statuses, variants_by_status, strict=True)
                 for variant in variants.get(key, [])
+                if variant["count"] == status["count"]
             ]
-            stable.extend(representatives[:stable_multiplicity])
+            stable.extend(sorted(representatives)[:stable_multiplicity])
         return sorted(stable)
 
     def _project_status(self, project_data: RunOutput) -> _ProjectStatus:
@@ -521,9 +534,12 @@ class DiagnosticDiff:
                 new_status,
             }
             if not failure_transition_is_flaky and (old_failed or new_failed):
-                introduced_panics, fixed_panics, persistent_panics = (
-                    _compare_panic_messages(old_panics, new_panics)
-                )
+                (
+                    introduced_panics,
+                    fixed_panics,
+                    old_persistent_panics,
+                    new_persistent_panics,
+                ) = _partition_panic_messages(old_panics, new_panics)
                 abnormal_exit_kind_changed = (
                     old_status is _ProjectStatus.ABNORMAL_EXIT
                     and new_status is _ProjectStatus.ABNORMAL_EXIT
@@ -578,7 +594,9 @@ class DiagnosticDiff:
                     "new_panic_messages": new_panics,
                     "introduced_panic_messages": introduced_panics,
                     "fixed_panic_messages": fixed_panics,
-                    "persistent_panic_messages": persistent_panics,
+                    "persistent_panic_messages": new_persistent_panics,
+                    "old_persistent_panic_messages": old_persistent_panics,
+                    "new_persistent_panic_messages": new_persistent_panics,
                     "failure_status": failure_status,
                 }
                 self._add_project_kind(entry, new_project)

--- a/src/ecosystem_analyzer/templates/diff.html
+++ b/src/ecosystem_analyzer/templates/diff.html
@@ -667,7 +667,7 @@
 </div>
 {% endmacro %}
 
-{% macro render_exit_statuses(statuses, runs) %}
+{% macro render_exit_statuses(statuses, runs, summarized_panic_messages=()) %}
 {% if not statuses %}
 <span style="color: #6c757d;">not present</span>
 {% endif %}
@@ -679,11 +679,16 @@
     exit code <code>{{ status.return_code }}</code>
     {% endif %}
 </div>
+{% set summarized_messages = namespace(remaining=summarized_panic_messages | list) %}
 {% for variant in status.get("panic_messages", []) %}
+{% if variant.count == status.count and variant.message in summarized_messages.remaining %}
+{% set _ = summarized_messages.remaining.remove(variant.message) %}
+{% else %}
 <details class="failure-output-block panic-block-neutral">
     <summary>panic ({{ variant.count }}/{{ runs }} runs)</summary>
     <pre>{{ variant.message | e }}</pre>
 </details>
+{% endif %}
 {% endfor %}
 {% for variant in status.get("stderr", []) %}
 <details class="failure-output-block">
@@ -860,6 +865,8 @@
                 <tbody>
                     {% for project in diffs.failed_projects %}
                     {% set failure_status = project.failure_status %}
+                    {% set old_summarized_panic_messages = project.fixed_panic_messages + project.old_persistent_panic_messages %}
+                    {% set new_summarized_panic_messages = project.introduced_panic_messages + project.new_persistent_panic_messages %}
                     <tr class="failed-row-{{ failure_status }}" style="border-bottom: 1px solid rgba(38, 18, 48, 0.1);">
                         <td style="padding: 12px;">
                             <strong>{{ project.project }}</strong>
@@ -887,10 +894,10 @@
                             {% endif %}
                         </td>
                         <td style="padding: 12px; text-align: center; font-family: 'Fira Code', monospace;">
-                            {{ render_exit_statuses(project.old_exit_statuses, project.old_runs) }}
+                            {{ render_exit_statuses(project.old_exit_statuses, project.old_runs, summarized_panic_messages=old_summarized_panic_messages) }}
                         </td>
                         <td style="padding: 12px; text-align: center; font-family: 'Fira Code', monospace;">
-                            {{ render_exit_statuses(project.new_exit_statuses, project.new_runs) }}
+                            {{ render_exit_statuses(project.new_exit_statuses, project.new_runs, summarized_panic_messages=new_summarized_panic_messages) }}
                         </td>
                     </tr>
                     {% if project.old_panic_messages or project.new_panic_messages %}
@@ -912,7 +919,14 @@
                             {% if project.persistent_panic_messages %}
                             <details class="failure-output-block panic-block-persistent">
                                 <summary>➖ Persistent panic message{{ 's' if project.persistent_panic_messages|length != 1 }} (present on both baseline and PR)</summary>
+                                {% if project.old_persistent_panic_messages != project.new_persistent_panic_messages %}
+                                <strong>Baseline</strong>
+                                <pre>{{ project.old_persistent_panic_messages | join('\n') | e }}</pre>
+                                <strong>PR</strong>
+                                <pre>{{ project.new_persistent_panic_messages | join('\n') | e }}</pre>
+                                {% else %}
                                 <pre>{{ project.persistent_panic_messages | join('\n') | e }}</pre>
+                                {% endif %}
                             </details>
                             {% endif %}
                         </td>

--- a/tests/test_json_roundtrip.py
+++ b/tests/test_json_roundtrip.py
@@ -521,6 +521,139 @@ class TestJsonRoundtrip:
         assert "&lt;img src=x onerror=alert" in html
         assert "&lt;svg onload=alert" in html
 
+    def test_failed_project_panic_messages_only_render_in_full_width_row(self):
+        old_only = "panic from the baseline"
+        new_only = "panic from the PR"
+        persistent = "panic on both revisions"
+        diff = _make_diff(
+            [_make_failed_output("proj", panic_messages=[old_only, persistent])],
+            [_make_failed_output("proj", panic_messages=[new_only, persistent])],
+        )
+
+        html = _render_html(diff)
+
+        assert "<summary>panic (1/1 runs)</summary>" not in html
+        assert html.count(old_only) == 1
+        assert html.count(new_only) == 1
+        assert html.count(persistent) == 1
+        assert "New panic message (introduced by this PR)" in html
+        assert "Previous panic message (no longer present)" in html
+        assert "Persistent panic message (present on both baseline and PR)" in html
+
+    def test_failed_project_preserves_nonduplicated_panic_evidence(self):
+        intermittent = (
+            "Panicked at crates/ty_python_semantic/src/types/infer.rs:70:9 "
+            "when checking `example.py`: `query error`"
+        )
+        stable = (
+            "Panicked at crates/ty_python_semantic/src/types/infer.rs:80:9 "
+            "when checking `example.py`: `query error`"
+        )
+        statuses = [
+            {
+                "return_code": 101,
+                "count": 3,
+                "panic_messages": [
+                    {"message": intermittent, "count": 1},
+                    {"message": stable, "count": 3},
+                ],
+            }
+        ]
+        diff = _make_diff(
+            [
+                _make_output(
+                    "proj", [], flaky_runs=3, exit_statuses=statuses, time_s=None
+                )
+            ],
+            [
+                _make_output(
+                    "proj", [], flaky_runs=3, exit_statuses=statuses, time_s=None
+                )
+            ],
+        )
+
+        html = _render_html(diff)
+
+        entry = diff.diffs["failed_projects"][0]
+        assert entry["persistent_panic_messages"] == [stable]
+        assert html.count(intermittent) == 2
+        assert html.count(stable) == 1
+        assert html.count("<summary>panic (1/3 runs)</summary>") == 2
+        assert "<summary>panic (3/3 runs)</summary>" not in html
+
+    def test_failed_project_preserves_panic_that_becomes_stable(self):
+        panic = "panic that becomes stable"
+        old_statuses = [
+            {
+                "return_code": 101,
+                "count": 3,
+                "panic_messages": [{"message": panic, "count": 1}],
+            }
+        ]
+        new_statuses = [
+            {
+                "return_code": 101,
+                "count": 3,
+                "panic_messages": [{"message": panic, "count": 3}],
+            }
+        ]
+        diff = _make_diff(
+            [
+                _make_output(
+                    "proj", [], flaky_runs=3, exit_statuses=old_statuses, time_s=None
+                )
+            ],
+            [
+                _make_output(
+                    "proj", [], flaky_runs=3, exit_statuses=new_statuses, time_s=None
+                )
+            ],
+        )
+
+        html = _render_html(diff)
+
+        assert html.count(panic) == 2
+        assert html.count("<summary>panic (1/3 runs)</summary>") == 1
+        assert "<summary>panic (3/3 runs)</summary>" not in html
+        assert "New panic message (introduced by this PR)" in html
+
+    def test_failed_project_preserves_raw_evidence_across_exit_statuses(self):
+        def panic_at(line: int) -> str:
+            return (
+                "Panicked at crates/ty_python_semantic/src/types/infer.rs:"
+                f"{line}:9 when checking `example.py`: `query error`"
+            )
+
+        statuses = [
+            {
+                "return_code": 101,
+                "count": 1,
+                "panic_messages": [{"message": panic_at(70), "count": 1}],
+            },
+            {
+                "return_code": 139,
+                "count": 1,
+                "panic_messages": [{"message": panic_at(80), "count": 1}],
+            },
+        ]
+        diff = _make_diff(
+            [_make_output("proj", [], exit_statuses=statuses, time_s=None)],
+            [
+                _make_output(
+                    "proj", [], exit_statuses=list(reversed(statuses)), time_s=None
+                )
+            ],
+        )
+
+        html = _render_html(diff)
+
+        entry = diff.diffs["failed_projects"][0]
+        assert entry["old_persistent_panic_messages"] == [panic_at(70)]
+        assert entry["new_persistent_panic_messages"] == [panic_at(70)]
+        assert html.count(panic_at(70)) == 1
+        assert html.count(panic_at(80)) == 2
+        assert html.count("<summary>panic (1/2 runs)</summary>") == 2
+
     def test_persistent_failures_hidden_from_markdown_table(self):
         """Projects failing on both sides are kept out of the PR-comment
         summary table but remain in the full diff data (for the HTML report)."""
@@ -635,6 +768,14 @@ info: query stacktrace:
             assert entry["old_panic_messages"] == [old_panics[project]]
             assert entry["new_panic_messages"] == [new_panic]
 
+        html = _render_html(diff)
+        assert "<summary>panic (1/1 runs)</summary>" not in html
+        assert html.count("<strong>Baseline</strong>") == 2
+        assert html.count("<strong>PR</strong>") == 2
+        for project, new_panic in new_panics.items():
+            assert old_panics[project] in html
+            assert new_panic in html
+
         assert not diff.has_new_panics()
         assert diff.generate_comment_title() == "## `ecosystem-analyzer` results"
 
@@ -691,6 +832,12 @@ info: Args: /tmp/new_commit/ty check ."""
         assert removed_entry["introduced_panic_messages"] == []
         assert removed_entry["fixed_panic_messages"] == [panic_at(60)]
         assert removed_entry["persistent_panic_messages"] == two_panics
+
+        html = _render_html(diff)
+        assert "<summary>panic (1/1 runs)</summary>" not in html
+        assert html.count(panic_at(60)) == 2
+        assert html.count(panic_at(70)) == 2
+        assert html.count(panic_at(80)) == 2
 
     def test_introduced_project_failures_detects_new_abnormal_exit_code(self):
         diff = _make_diff(


### PR DESCRIPTION
## Summary

- render stable panic messages once in the full-width failure-details row instead of duplicating each message in the narrow outcome columns
- retain intermittent, extra-multiplicity, and per-exit-status panic evidence in the outcome cells
- show separate baseline and PR raw text when normalized persistent panics differ

## Context

Stable panics were previously rendered twice: once as an individual dropdown for every panic in the outcome cell, and again in the full-width panic summary below. Reports with many panics became extremely tall, hard to scan, and unnecessarily expensive for the browser to render.

The report now suppresses only panic evidence that is fully represented by the full-width summary. Flaky panic evidence remains expandable alongside its observed outcome.
