### PR TITLE
Update mypy-primer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "A tool for analyzing Python projects with ty"
 dependencies = [
     "gitpython==3.1.51",
-    "mypy-primer @ git+https://github.com/hauntsaninja/mypy_primer@ff3d9531335dad605d43fcc208c9c159bb09fa81",
+    "mypy-primer @ git+https://github.com/hauntsaninja/mypy_primer@eb1c48d6db2984f5ab083b8355f3647cb4d167a5",
     "click==8.4.2",
     "jinja2==3.1.6",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -45,7 +45,7 @@ requires-dist = [
     { name = "click", specifier = "==8.4.2" },
     { name = "gitpython", specifier = "==3.1.51" },
     { name = "jinja2", specifier = "==3.1.6" },
-    { name = "mypy-primer", git = "https://github.com/hauntsaninja/mypy_primer?rev=ff3d9531335dad605d43fcc208c9c159bb09fa81" },
+    { name = "mypy-primer", git = "https://github.com/hauntsaninja/mypy_primer?rev=eb1c48d6db2984f5ab083b8355f3647cb4d167a5" },
 ]
 
 [package.metadata.requires-dev]
@@ -154,7 +154,7 @@ wheels = [
 [[package]]
 name = "mypy-primer"
 version = "0.1.0"
-source = { git = "https://github.com/hauntsaninja/mypy_primer?rev=ff3d9531335dad605d43fcc208c9c159bb09fa81#ff3d9531335dad605d43fcc208c9c159bb09fa81" }
+source = { git = "https://github.com/hauntsaninja/mypy_primer?rev=eb1c48d6db2984f5ab083b8355f3647cb4d167a5#eb1c48d6db2984f5ab083b8355f3647cb4d167a5" }
 
 [[package]]
 name = "packaging"


### PR DESCRIPTION
## Summary

- Bump mypy-primer from `ff3d9531335dad605d43fcc208c9c159bb09fa81` to `eb1c48d6db2984f5ab083b8355f3647cb4d167a5`.
- Pick up [hauntsaninja/mypy_primer#256](https://github.com/hauntsaninja/mypy_primer/pull/256), which updates the `svcs` typing-test path.

## Why

`svcs` moved its typing tests from `tests/typing` to `typing_tests` in [hynek/svcs#177](https://github.com/hynek/svcs/pull/177). The old mypy-primer pin still asks ecosystem-analyzer to run `ty check src tests/typing`, so ty reports the missing path as an I/O error and exits with status 2. This appears as a persistent abnormal exit in Ruff's ecosystem-analyzer report.

## Validation

- `uv run --frozen pytest` (`130 passed`)
- `uv run --frozen ty check`
- `uvx prek run --all-files`
- Verified the resolved `svcs` project paths are `['src', 'typing_tests']`.
