### PR TITLE
Update mypy-primer to fix attrs and Bokeh project configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "A tool for analyzing Python projects with ty"
 dependencies = [
     "gitpython==3.1.57",
-    "mypy-primer @ git+https://github.com/hauntsaninja/mypy_primer@eb1c48d6db2984f5ab083b8355f3647cb4d167a5",
+    "mypy-primer @ git+https://github.com/hauntsaninja/mypy_primer@6d6eebd8d37c9b8931381e79aa99808d9378c988",
     "click==8.4.2",
     "jinja2==3.1.6",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -45,7 +45,7 @@ requires-dist = [
     { name = "click", specifier = "==8.4.2" },
     { name = "gitpython", specifier = "==3.1.57" },
     { name = "jinja2", specifier = "==3.1.6" },
-    { name = "mypy-primer", git = "https://github.com/hauntsaninja/mypy_primer?rev=eb1c48d6db2984f5ab083b8355f3647cb4d167a5" },
+    { name = "mypy-primer", git = "https://github.com/hauntsaninja/mypy_primer?rev=6d6eebd8d37c9b8931381e79aa99808d9378c988" },
 ]
 
 [package.metadata.requires-dev]
@@ -154,7 +154,7 @@ wheels = [
 [[package]]
 name = "mypy-primer"
 version = "0.1.0"
-source = { git = "https://github.com/hauntsaninja/mypy_primer?rev=eb1c48d6db2984f5ab083b8355f3647cb4d167a5#eb1c48d6db2984f5ab083b8355f3647cb4d167a5" }
+source = { git = "https://github.com/hauntsaninja/mypy_primer?rev=6d6eebd8d37c9b8931381e79aa99808d9378c988#6d6eebd8d37c9b8931381e79aa99808d9378c988" }
 
 [[package]]
 name = "packaging"


### PR DESCRIPTION
Updates the pinned mypy-primer revision to https://github.com/hauntsaninja/mypy_primer/pull/257.

The updated project definitions:

- Follow the attrs typing test directory rename to `typing_tests`.
- Follow Bokeh release tooling to `tools/release`.
- Run Bokeh under Python 3.12, matching its minimum supported Python version.

This restores both projects to ecosystem analysis after stale paths caused persistent exit-code-2 failures on the baseline and PR revisions.

Validation:

- `uv run --locked pytest -q` — 130 passed.
- `uv run --locked ty check`.
- `uvx prek run --files pyproject.toml uv.lock`.
- Ran the actual analyzer on attrs and Bokeh; both returned normal exit code 1.
