### PR TITLE
Require TypedDict fields and simplify dictionary access

### DIFF
--- a/src/ecosystem_analyzer/diff.py
+++ b/src/ecosystem_analyzer/diff.py
@@ -204,7 +204,7 @@ class DiagnosticDiff:
         Includes locations from both stable diagnostics and flaky variants.
         """
         locs: set[SourceLocationKey] = set()
-        for d in project.get("diagnostics", []):
+        for d in project["diagnostics"]:
             locs.add((d["path"], d["line"], d["column"]))
         for loc in project.get("flaky_diagnostics", []):
             locs.add((loc["path"], loc["line"], loc["column"]))
@@ -332,7 +332,7 @@ class DiagnosticDiff:
         """Count the total number of diagnostics in the data."""
         total_diagnostics = 0
         for output in data["outputs"]:
-            total_diagnostics += len(output.get("diagnostics", []))
+            total_diagnostics += len(output["diagnostics"])
         return total_diagnostics
 
     def _format_diagnostic(self, diag: Diagnostic) -> str:
@@ -620,14 +620,14 @@ class DiagnosticDiff:
         for project_name in sorted(old_projects.keys()):
             if project_name not in new_projects:
                 project_data = old_projects[project_name]
-                diagnostics = project_data.get("diagnostics", [])
+                diagnostics = project_data["diagnostics"]
                 diagnostics = sorted(
                     diagnostics,
                     key=lambda d: (
-                        d.get("path", ""),
-                        d.get("line", 0),
-                        d.get("column", 0),
-                        d.get("message", ""),
+                        d["path"],
+                        d["line"],
+                        d["column"],
+                        d["message"],
                     ),
                 )
                 removed_project: AddedOrRemovedProjectDiff = {
@@ -657,14 +657,14 @@ class DiagnosticDiff:
         for project_name in sorted(new_projects.keys()):
             if project_name not in old_projects:
                 project_data = new_projects[project_name]
-                diagnostics = project_data.get("diagnostics", [])
+                diagnostics = project_data["diagnostics"]
                 diagnostics = sorted(
                     diagnostics,
                     key=lambda d: (
-                        d.get("path", ""),
-                        d.get("line", 0),
-                        d.get("column", 0),
-                        d.get("message", ""),
+                        d["path"],
+                        d["line"],
+                        d["column"],
+                        d["message"],
                     ),
                 )
                 added_project: AddedOrRemovedProjectDiff = {
@@ -716,12 +716,12 @@ class DiagnosticDiff:
 
             old_diagnostics = [
                 d
-                for d in old_project.get("diagnostics", [])
+                for d in old_project["diagnostics"]
                 if (d["path"], d["line"], d["column"]) not in all_flaky_locs
             ]
             new_diagnostics = [
                 d
-                for d in new_project.get("diagnostics", [])
+                for d in new_project["diagnostics"]
                 if (d["path"], d["line"], d["column"]) not in all_flaky_locs
             ]
 
@@ -847,9 +847,9 @@ class DiagnosticDiff:
                 diagnostics = sorted(
                     diagnostics,
                     key=lambda d: (
-                        d.get("line", 0),
-                        d.get("column", 0),
-                        d.get("message", ""),
+                        d["line"],
+                        d["column"],
+                        d["message"],
                     ),
                 )
                 result["removed_files"].append({
@@ -865,9 +865,9 @@ class DiagnosticDiff:
                 diagnostics = sorted(
                     diagnostics,
                     key=lambda d: (
-                        d.get("line", 0),
-                        d.get("column", 0),
-                        d.get("message", ""),
+                        d["line"],
+                        d["column"],
+                        d["message"],
                     ),
                 )
                 result["added_files"].append({
@@ -914,7 +914,7 @@ class DiagnosticDiff:
         for line_num, diags in result.items():
             result[line_num] = sorted(
                 diags,
-                key=lambda d: (d.get("column", 0), d.get("message", "")),
+                key=lambda d: (d["column"], d["message"]),
             )
         return result
 
@@ -937,7 +937,7 @@ class DiagnosticDiff:
                 # Sort diagnostics by column, message
                 diagnostics = sorted(
                     diagnostics,
-                    key=lambda d: (d.get("column", 0), d.get("message", "")),
+                    key=lambda d: (d["column"], d["message"]),
                 )
                 result["removed_lines"].append({
                     "line": line_num,
@@ -951,7 +951,7 @@ class DiagnosticDiff:
                 # Sort diagnostics by column, message
                 diagnostics = sorted(
                     diagnostics,
-                    key=lambda d: (d.get("column", 0), d.get("message", "")),
+                    key=lambda d: (d["column"], d["message"]),
                 )
                 result["added_lines"].append({
                     "line": line_num,
@@ -1019,11 +1019,11 @@ class DiagnosticDiff:
                 # Sort removed and added diagnostics
                 removed_diagnostics = sorted(
                     removed_diagnostics,
-                    key=lambda d: (d.get("column", 0), d.get("message", "")),
+                    key=lambda d: (d["column"], d["message"]),
                 )
                 added_diagnostics = sorted(
                     added_diagnostics,
-                    key=lambda d: (d.get("column", 0), d.get("message", "")),
+                    key=lambda d: (d["column"], d["message"]),
                 )
 
                 result["modified_lines"].append({
@@ -1239,13 +1239,12 @@ class DiagnosticDiff:
         Stable diagnostics from projects that happen to also have flaky data
         are still counted.
         """
-        # Intermediate dictionaries (local variables)
-        added_by_lint: dict[str, int] = {}
-        removed_by_lint: dict[str, int] = {}
-        changed_by_lint: dict[str, int] = {}
-        added_by_project: dict[str, int] = {}
-        removed_by_project: dict[str, int] = {}
-        changed_by_project: dict[str, int] = {}
+        added_by_lint: Counter[str] = Counter()
+        removed_by_lint: Counter[str] = Counter()
+        changed_by_lint: Counter[str] = Counter()
+        added_by_project: Counter[str] = Counter()
+        removed_by_project: Counter[str] = Counter()
+        changed_by_project: Counter[str] = Counter()
 
         total_added = 0
         total_removed = 0
@@ -1256,101 +1255,77 @@ class DiagnosticDiff:
             project_name = project["project"]
             for diag in project["diagnostics"]:
                 total_added += 1
-                lint_name = diag.get("lint_name", "unknown")
-                added_by_lint[lint_name] = added_by_lint.get(lint_name, 0) + 1
-                added_by_project[project_name] = (
-                    added_by_project.get(project_name, 0) + 1
-                )
+                lint_name = diag["lint_name"]
+                added_by_lint[lint_name] += 1
+                added_by_project[project_name] += 1
 
         # Count diagnostics from removed projects
         for project in self.diffs["removed_projects"]:
             project_name = project["project"]
             for diag in project["diagnostics"]:
                 total_removed += 1
-                lint_name = diag.get("lint_name", "unknown")
-                removed_by_lint[lint_name] = removed_by_lint.get(lint_name, 0) + 1
-                removed_by_project[project_name] = (
-                    removed_by_project.get(project_name, 0) + 1
-                )
+                lint_name = diag["lint_name"]
+                removed_by_lint[lint_name] += 1
+                removed_by_project[project_name] += 1
 
         # Count diagnostics from modified projects
         for project in self.diffs["modified_projects"]:
             project_name = project["project"]
             # Added files in modified projects
-            for file_data in project["diffs"].get("added_files", []):
+            for file_data in project["diffs"]["added_files"]:
                 for diag in file_data["diagnostics"]:
                     total_added += 1
-                    lint_name = diag.get("lint_name", "unknown")
-                    added_by_lint[lint_name] = added_by_lint.get(lint_name, 0) + 1
-                    added_by_project[project_name] = (
-                        added_by_project.get(project_name, 0) + 1
-                    )
+                    lint_name = diag["lint_name"]
+                    added_by_lint[lint_name] += 1
+                    added_by_project[project_name] += 1
 
             # Removed files in modified projects
-            for file_data in project["diffs"].get("removed_files", []):
+            for file_data in project["diffs"]["removed_files"]:
                 for diag in file_data["diagnostics"]:
                     total_removed += 1
-                    lint_name = diag.get("lint_name", "unknown")
-                    removed_by_lint[lint_name] = removed_by_lint.get(lint_name, 0) + 1
-                    removed_by_project[project_name] = (
-                        removed_by_project.get(project_name, 0) + 1
-                    )
+                    lint_name = diag["lint_name"]
+                    removed_by_lint[lint_name] += 1
+                    removed_by_project[project_name] += 1
 
             # Modified files in modified projects
-            for file_data in project["diffs"].get("modified_files", []):
+            for file_data in project["diffs"]["modified_files"]:
                 # Added lines
-                for line_data in file_data["diffs"].get("added_lines", []):
+                for line_data in file_data["diffs"]["added_lines"]:
                     for diag in line_data["diagnostics"]:
                         total_added += 1
-                        lint_name = diag.get("lint_name", "unknown")
-                        added_by_lint[lint_name] = added_by_lint.get(lint_name, 0) + 1
-                        added_by_project[project_name] = (
-                            added_by_project.get(project_name, 0) + 1
-                        )
+                        lint_name = diag["lint_name"]
+                        added_by_lint[lint_name] += 1
+                        added_by_project[project_name] += 1
 
                 # Removed lines
-                for line_data in file_data["diffs"].get("removed_lines", []):
+                for line_data in file_data["diffs"]["removed_lines"]:
                     for diag in line_data["diagnostics"]:
                         total_removed += 1
-                        lint_name = diag.get("lint_name", "unknown")
-                        removed_by_lint[lint_name] = (
-                            removed_by_lint.get(lint_name, 0) + 1
-                        )
-                        removed_by_project[project_name] = (
-                            removed_by_project.get(project_name, 0) + 1
-                        )
+                        lint_name = diag["lint_name"]
+                        removed_by_lint[lint_name] += 1
+                        removed_by_project[project_name] += 1
 
                 # Modified lines
-                for line_data in file_data["diffs"].get("modified_lines", []):
+                for line_data in file_data["diffs"]["modified_lines"]:
                     # Count text_diffs as changed diagnostics
-                    for diff_item in line_data.get("text_diffs", []):
+                    for diff_item in line_data["text_diffs"]:
                         total_changed += 1
-                        lint_name = diff_item["old"].get("lint_name", "unknown")
-                        changed_by_lint[lint_name] = (
-                            changed_by_lint.get(lint_name, 0) + 1
-                        )
-                        changed_by_project[project_name] = (
-                            changed_by_project.get(project_name, 0) + 1
-                        )
+                        lint_name = diff_item["old"]["lint_name"]
+                        changed_by_lint[lint_name] += 1
+                        changed_by_project[project_name] += 1
 
                     # Count pure additions and removals (already filtered in diff computation)
                     for diag in line_data["added"]:
                         total_added += 1
-                        lint_name = diag.get("lint_name", "unknown")
-                        added_by_lint[lint_name] = added_by_lint.get(lint_name, 0) + 1
-                        added_by_project[project_name] = (
-                            added_by_project.get(project_name, 0) + 1
-                        )
+                        lint_name = diag["lint_name"]
+                        added_by_lint[lint_name] += 1
+                        added_by_project[project_name] += 1
 
                     for diag in line_data["removed"]:
                         total_removed += 1
-                        lint_name = diag.get("lint_name", "unknown")
-                        removed_by_lint[lint_name] = (
-                            removed_by_lint.get(lint_name, 0) + 1
-                        )
-                        removed_by_project[project_name] = (
-                            removed_by_project.get(project_name, 0) + 1
-                        )
+                        lint_name = diag["lint_name"]
+                        removed_by_lint[lint_name] += 1
+                        removed_by_project[project_name] += 1
 
             # Flaky location diffs are excluded from statistics — they
             # are still shown in the HTML report for manual inspection.
@@ -1364,9 +1339,9 @@ class DiagnosticDiff:
         merged_lints: list[MergedLintStats] = []
 
         for lint_name in all_lints:
-            added_count = added_by_lint.get(lint_name, 0)
-            removed_count = removed_by_lint.get(lint_name, 0)
-            changed_count = changed_by_lint.get(lint_name, 0)
+            added_count = added_by_lint[lint_name]
+            removed_count = removed_by_lint[lint_name]
+            changed_count = changed_by_lint[lint_name]
             total_change = added_count + removed_count + changed_count
             merged_lints.append({
                 "lint_name": lint_name,
@@ -1396,9 +1371,9 @@ class DiagnosticDiff:
         merged_projects: list[MergedProjectStats] = []
 
         for project_name in all_projects:
-            added_count = added_by_project.get(project_name, 0)
-            removed_count = removed_by_project.get(project_name, 0)
-            changed_count = changed_by_project.get(project_name, 0)
+            added_count = added_by_project[project_name]
+            removed_count = removed_by_project[project_name]
+            changed_count = changed_by_project[project_name]
             total_change = added_count + removed_count + changed_count
             merged_projects.append({
                 "project_name": project_name,
@@ -1417,7 +1392,7 @@ class DiagnosticDiff:
             "total_added": total_added,
             "total_removed": total_removed,
             "total_changed": total_changed,
-            "failed_projects": len(self.diffs.get("failed_projects", [])),
+            "failed_projects": len(self.diffs["failed_projects"]),
             "merged_by_lint": merged_lints,
             "merged_by_project": merged_projects,
         }
@@ -1432,7 +1407,7 @@ class DiagnosticDiff:
         """Return project names that regressed from a normal exit to an abnormal exit or timeout."""
         return [
             project["project"]
-            for project in self.diffs.get("failed_projects", [])
+            for project in self.diffs["failed_projects"]
             if project["failure_status"] == "new"
         ]
 
@@ -1440,13 +1415,13 @@ class DiagnosticDiff:
         """Check if any still-failing project gained panic messages."""
         return any(
             project["failure_status"] == "new_panics"
-            for project in self.diffs.get("failed_projects", [])
+            for project in self.diffs["failed_projects"]
         )
 
     def generate_comment_title(self) -> str:
         """Generate the PR comment title with status indicators for new failures."""
         title = "## `ecosystem-analyzer` results"
-        failed_projects = self.diffs.get("failed_projects", [])
+        failed_projects = self.diffs["failed_projects"]
         failure_statuses = {project["failure_status"] for project in failed_projects}
         new_projects = [
             project for project in failed_projects if project["failure_status"] == "new"
@@ -1487,7 +1462,7 @@ class DiagnosticDiff:
 
     def _has_flaky_changes(self) -> bool:
         """Check whether any flaky changes were omitted from the raw diff."""
-        if self.diffs.get("flaky_exit_status_changes"):
+        if self.diffs["flaky_exit_status_changes"]:
             return True
         if any(
             project.get("flaky_diagnostics")
@@ -1497,11 +1472,8 @@ class DiagnosticDiff:
         ):
             return True
         for project in self.diffs["modified_projects"]:
-            flaky_diffs = project.get("flaky_diffs", {})
-            if (
-                flaky_diffs.get("added")
-                or flaky_diffs.get("removed")
-                or flaky_diffs.get("changed")
+            if (flaky_diffs := project.get("flaky_diffs")) and (
+                flaky_diffs["added"] or flaky_diffs["removed"] or flaky_diffs["changed"]
             ):
                 return True
         return False
@@ -1513,7 +1485,7 @@ class DiagnosticDiff:
 
         def add_entry(
             project_name: str,
-            project_location: str | None,
+            project_location: str,
             lines: list[str],
             *,
             counts_as_change: bool = True,
@@ -1576,14 +1548,14 @@ class DiagnosticDiff:
                     )
             add_entry(
                 project["project"],
-                project.get("project_location"),
+                project["project_location"],
                 [line],
                 counts_as_change=False,
             )
 
         for project in self.diffs["removed_projects"]:
             project_name = project["project"]
-            project_location = project.get("project_location")
+            project_location = project["project_location"]
             for diag in project["diagnostics"]:
                 add_entry(
                     project_name,
@@ -1592,7 +1564,7 @@ class DiagnosticDiff:
                 )
         for project in self.diffs["added_projects"]:
             project_name = project["project"]
-            project_location = project.get("project_location")
+            project_location = project["project_location"]
             for diag in project["diagnostics"]:
                 add_entry(
                     project_name,
@@ -1601,10 +1573,10 @@ class DiagnosticDiff:
                 )
         for project in self.diffs["modified_projects"]:
             project_name = project["project"]
-            project_location = project.get("project_location")
+            project_location = project["project_location"]
             diffs = project["diffs"]
 
-            for file_data in diffs.get("removed_files", []):
+            for file_data in diffs["removed_files"]:
                 for diag in file_data["diagnostics"]:
                     add_entry(
                         project_name,
@@ -1612,7 +1584,7 @@ class DiagnosticDiff:
                         [f"- {self._format_short_diagnostic(diag)}"],
                     )
 
-            for file_data in diffs.get("added_files", []):
+            for file_data in diffs["added_files"]:
                 for diag in file_data["diagnostics"]:
                     add_entry(
                         project_name,
@@ -1620,8 +1592,8 @@ class DiagnosticDiff:
                         [f"+ {self._format_short_diagnostic(diag)}"],
                     )
 
-            for file_data in diffs.get("modified_files", []):
-                for line_data in file_data["diffs"].get("removed_lines", []):
+            for file_data in diffs["modified_files"]:
+                for line_data in file_data["diffs"]["removed_lines"]:
                     for diag in line_data["diagnostics"]:
                         add_entry(
                             project_name,
@@ -1629,7 +1601,7 @@ class DiagnosticDiff:
                             [f"- {self._format_short_diagnostic(diag)}"],
                         )
 
-                for line_data in file_data["diffs"].get("added_lines", []):
+                for line_data in file_data["diffs"]["added_lines"]:
                     for diag in line_data["diagnostics"]:
                         add_entry(
                             project_name,
@@ -1637,8 +1609,8 @@ class DiagnosticDiff:
                             [f"+ {self._format_short_diagnostic(diag)}"],
                         )
 
-                for line_data in file_data["diffs"].get("modified_lines", []):
-                    for diff_item in line_data.get("text_diffs", []):
+                for line_data in file_data["diffs"]["modified_lines"]:
+                    for diff_item in line_data["text_diffs"]:
                         add_entry(
                             project_name,
                             project_location,
@@ -1676,7 +1648,7 @@ class DiagnosticDiff:
         """Render the pull-request summary of diagnostic and failure changes."""
 
         statistics = self._calculate_statistics()
-        failed_projects = self.diffs.get("failed_projects", [])
+        failed_projects = self.diffs["failed_projects"]
 
         markdown_content = self.generate_comment_title() + "\n\n"
 
@@ -1991,8 +1963,8 @@ class DiagnosticDiff:
             }:
                 continue
 
-            old_time = old_project.get("median_time_s")
-            new_time = new_project.get("median_time_s")
+            old_time = old_project["median_time_s"]
+            new_time = new_project["median_time_s"]
 
             # Imported diagnostic output may have a known successful exit status
             # without a measured runtime. It has no useful timing comparison.
@@ -2080,20 +2052,16 @@ class DiagnosticDiff:
             }
 
         # Filter out failed runs and infinite values for statistical calculations
-        valid_data = [row for row in timing_data if not row.get("is_failed", False)]
+        valid_data = [row for row in timing_data if not row["is_failed"]]
         factors = [row["factor"] for row in valid_data if row["factor"] != float("inf")]
 
         speedups = sum(1 for row in valid_data if row["factor"] < 0.9)
         slowdowns = sum(1 for row in valid_data if row["factor"] > 1.1)
         timeouts = sum(
-            1
-            for row in timing_data
-            if row.get("old_is_timeout", False) or row.get("new_is_timeout", False)
+            1 for row in timing_data if row["old_is_timeout"] or row["new_is_timeout"]
         )
         abnormal_exits = sum(
-            1
-            for row in timing_data
-            if row.get("old_is_abnormal", False) or row.get("new_is_abnormal", False)
+            1 for row in timing_data if row["old_is_abnormal"] or row["new_is_abnormal"]
         )
 
         avg_factor = sum(factors) / len(factors) if factors else 1.0
@@ -2113,7 +2081,7 @@ class DiagnosticDiff:
         large_changes: list[LargeTimingChange] = []
 
         for row in timing_data:
-            if row.get("is_failed", False):
+            if row["is_failed"]:
                 continue
 
             factor = row["factor"]

--- a/src/ecosystem_analyzer/diff.py
+++ b/src/ecosystem_analyzer/diff.py
@@ -206,7 +206,7 @@ class DiagnosticDiff:
         locs: set[SourceLocationKey] = set()
         for d in project["diagnostics"]:
             locs.add((d["path"], d["line"], d["column"]))
-        for loc in project.get("flaky_diagnostics", []):
+        for loc in project["flaky_diagnostics"]:
             locs.add((loc["path"], loc["line"], loc["column"]))
         return locs
 
@@ -246,7 +246,7 @@ class DiagnosticDiff:
 
     @staticmethod
     def _annotate_flaky_location(
-        location: FlakyLocation, flaky_runs: int | None
+        location: FlakyLocation, flaky_runs: int
     ) -> AnnotatedFlakyLocation:
         return {
             "path": location["path"],
@@ -260,8 +260,8 @@ class DiagnosticDiff:
         self,
         old_flaky: list[FlakyLocation],
         new_flaky: list[FlakyLocation],
-        old_flaky_runs: int | None,
-        new_flaky_runs: int | None,
+        old_flaky_runs: int,
+        new_flaky_runs: int,
     ) -> FlakyDiagnosticDiffData:
         """Compare flaky locations between old and new.
 
@@ -330,10 +330,7 @@ class DiagnosticDiff:
 
     def _count_diagnostics(self, data: RunData) -> int:
         """Count the total number of diagnostics in the data."""
-        total_diagnostics = 0
-        for output in data["outputs"]:
-            total_diagnostics += len(output["diagnostics"])
-        return total_diagnostics
+        return sum(len(output["diagnostics"]) for output in data["outputs"])
 
     def _format_diagnostic(self, diag: Diagnostic) -> str:
         """Format a diagnostic entry as a string for comparison."""
@@ -372,7 +369,7 @@ class DiagnosticDiff:
         all_keys = set()
         for status in statuses:
             variants_by_key: dict[str, list[OutputVariant]] = {}
-            for variant in status.get("panic_messages", []):
+            for variant in status["panic_messages"]:
                 [key] = index_panic_messages([variant["message"]])
                 all_keys.add(key)
                 variants_by_key.setdefault(key, []).append(variant)
@@ -426,7 +423,7 @@ class DiagnosticDiff:
         for status in statuses:
             if any(
                 variant["count"] != status["count"]
-                for variant in status.get("panic_messages", [])
+                for variant in status["panic_messages"]
             ):
                 return True
 
@@ -455,13 +452,13 @@ class DiagnosticDiff:
         old_panic_evidence = Counter(
             (status["return_code"], key)
             for status in old_statuses
-            for variant in status.get("panic_messages", [])
+            for variant in status["panic_messages"]
             for key in index_panic_messages([variant["message"]])
         )
         new_panic_evidence = Counter(
             (status["return_code"], key)
             for status in new_statuses
-            for variant in status.get("panic_messages", [])
+            for variant in status["panic_messages"]
             for key in index_panic_messages([variant["message"]])
         )
         old_stderr_evidence = {
@@ -636,12 +633,10 @@ class DiagnosticDiff:
                     "diagnostics": diagnostics,
                     "exit_statuses": self._exit_statuses(project_data),
                     "exit_status_runs": self._total_runs(project_data),
+                    "flaky_diagnostics": project_data["flaky_diagnostics"],
+                    "flaky_runs": project_data["flaky_runs"],
                 }
                 self._add_project_kind(removed_project, project_data)
-                flaky = project_data.get("flaky_diagnostics", [])
-                if flaky:
-                    removed_project["flaky_diagnostics"] = flaky
-                    removed_project["flaky_runs"] = project_data.get("flaky_runs")
                 if len(self._exit_statuses(project_data)) > 1:
                     result["flaky_exit_status_changes"].append({
                         "project": project_name,
@@ -673,12 +668,10 @@ class DiagnosticDiff:
                     "diagnostics": diagnostics,
                     "exit_statuses": self._exit_statuses(project_data),
                     "exit_status_runs": self._total_runs(project_data),
+                    "flaky_diagnostics": project_data["flaky_diagnostics"],
+                    "flaky_runs": project_data["flaky_runs"],
                 }
                 self._add_project_kind(added_project, project_data)
-                flaky = project_data.get("flaky_diagnostics", [])
-                if flaky:
-                    added_project["flaky_diagnostics"] = flaky
-                    added_project["flaky_runs"] = project_data.get("flaky_runs")
                 if len(self._exit_statuses(project_data)) > 1:
                     result["flaky_exit_status_changes"].append({
                         "project": project_name,
@@ -701,8 +694,8 @@ class DiagnosticDiff:
             old_project = old_projects[project_name]
             new_project = new_projects[project_name]
 
-            old_flaky = old_project.get("flaky_diagnostics", [])
-            new_flaky = new_project.get("flaky_diagnostics", [])
+            old_flaky = old_project["flaky_diagnostics"]
+            new_flaky = new_project["flaky_diagnostics"]
 
             # Reconcile stable vs flaky: exclude stable diagnostics at
             # locations that are flaky on either side.  A stable diagnostic
@@ -744,8 +737,8 @@ class DiagnosticDiff:
             flaky_diffs = self._compare_flaky_locations(
                 old_flaky_filtered,
                 new_flaky_filtered,
-                old_project.get("flaky_runs"),
-                new_project.get("flaky_runs"),
+                old_project["flaky_runs"],
+                new_project["flaky_runs"],
             )
 
             has_stable_changes = (
@@ -808,7 +801,7 @@ class DiagnosticDiff:
     @staticmethod
     def _project_kind(output: RunOutput) -> str | None:
         metadata = output.get("project_metadata")
-        return metadata.get("kind") if metadata is not None else None
+        return metadata["kind"] if metadata is not None else None
 
     @classmethod
     def _add_project_kind(cls, entry: ProjectInfo, output: RunOutput) -> None:
@@ -1246,26 +1239,18 @@ class DiagnosticDiff:
         removed_by_project: Counter[str] = Counter()
         changed_by_project: Counter[str] = Counter()
 
-        total_added = 0
-        total_removed = 0
-        total_changed = 0
-
         # Count diagnostics from added projects
         for project in self.diffs["added_projects"]:
             project_name = project["project"]
             for diag in project["diagnostics"]:
-                total_added += 1
-                lint_name = diag["lint_name"]
-                added_by_lint[lint_name] += 1
+                added_by_lint[diag["lint_name"]] += 1
                 added_by_project[project_name] += 1
 
         # Count diagnostics from removed projects
         for project in self.diffs["removed_projects"]:
             project_name = project["project"]
             for diag in project["diagnostics"]:
-                total_removed += 1
-                lint_name = diag["lint_name"]
-                removed_by_lint[lint_name] += 1
+                removed_by_lint[diag["lint_name"]] += 1
                 removed_by_project[project_name] += 1
 
         # Count diagnostics from modified projects
@@ -1274,17 +1259,13 @@ class DiagnosticDiff:
             # Added files in modified projects
             for file_data in project["diffs"]["added_files"]:
                 for diag in file_data["diagnostics"]:
-                    total_added += 1
-                    lint_name = diag["lint_name"]
-                    added_by_lint[lint_name] += 1
+                    added_by_lint[diag["lint_name"]] += 1
                     added_by_project[project_name] += 1
 
             # Removed files in modified projects
             for file_data in project["diffs"]["removed_files"]:
                 for diag in file_data["diagnostics"]:
-                    total_removed += 1
-                    lint_name = diag["lint_name"]
-                    removed_by_lint[lint_name] += 1
+                    removed_by_lint[diag["lint_name"]] += 1
                     removed_by_project[project_name] += 1
 
             # Modified files in modified projects
@@ -1292,39 +1273,29 @@ class DiagnosticDiff:
                 # Added lines
                 for line_data in file_data["diffs"]["added_lines"]:
                     for diag in line_data["diagnostics"]:
-                        total_added += 1
-                        lint_name = diag["lint_name"]
-                        added_by_lint[lint_name] += 1
+                        added_by_lint[diag["lint_name"]] += 1
                         added_by_project[project_name] += 1
 
                 # Removed lines
                 for line_data in file_data["diffs"]["removed_lines"]:
                     for diag in line_data["diagnostics"]:
-                        total_removed += 1
-                        lint_name = diag["lint_name"]
-                        removed_by_lint[lint_name] += 1
+                        removed_by_lint[diag["lint_name"]] += 1
                         removed_by_project[project_name] += 1
 
                 # Modified lines
                 for line_data in file_data["diffs"]["modified_lines"]:
                     # Count text_diffs as changed diagnostics
                     for diff_item in line_data["text_diffs"]:
-                        total_changed += 1
-                        lint_name = diff_item["old"]["lint_name"]
-                        changed_by_lint[lint_name] += 1
+                        changed_by_lint[diff_item["old"]["lint_name"]] += 1
                         changed_by_project[project_name] += 1
 
                     # Count pure additions and removals (already filtered in diff computation)
                     for diag in line_data["added"]:
-                        total_added += 1
-                        lint_name = diag["lint_name"]
-                        added_by_lint[lint_name] += 1
+                        added_by_lint[diag["lint_name"]] += 1
                         added_by_project[project_name] += 1
 
                     for diag in line_data["removed"]:
-                        total_removed += 1
-                        lint_name = diag["lint_name"]
-                        removed_by_lint[lint_name] += 1
+                        removed_by_lint[diag["lint_name"]] += 1
                         removed_by_project[project_name] += 1
 
             # Flaky location diffs are excluded from statistics — they
@@ -1332,9 +1303,7 @@ class DiagnosticDiff:
 
         # Create merged lint breakdown sorted by total absolute change (descending)
         all_lints = (
-            set(added_by_lint.keys())
-            | set(removed_by_lint.keys())
-            | set(changed_by_lint.keys())
+            added_by_lint.keys() | removed_by_lint.keys() | changed_by_lint.keys()
         )
         merged_lints: list[MergedLintStats] = []
 
@@ -1359,7 +1328,7 @@ class DiagnosticDiff:
         flaky_project_names: set[str] = {
             proj["project"]
             for proj in self.diffs["added_projects"]
-            if proj.get("flaky_diagnostics")
+            if proj["flaky_diagnostics"]
         }
 
         # Create merged project breakdown sorted by total absolute change (descending)
@@ -1389,9 +1358,9 @@ class DiagnosticDiff:
         merged_projects.sort(key=lambda x: (-x["total_change"], x["project_name"]))
 
         return {
-            "total_added": total_added,
-            "total_removed": total_removed,
-            "total_changed": total_changed,
+            "total_added": added_by_lint.total(),
+            "total_removed": removed_by_lint.total(),
+            "total_changed": changed_by_lint.total(),
             "failed_projects": len(self.diffs["failed_projects"]),
             "merged_by_lint": merged_lints,
             "merged_by_project": merged_projects,
@@ -1465,7 +1434,7 @@ class DiagnosticDiff:
         if self.diffs["flaky_exit_status_changes"]:
             return True
         if any(
-            project.get("flaky_diagnostics")
+            project["flaky_diagnostics"]
             for project in chain(
                 self.diffs["removed_projects"], self.diffs["added_projects"]
             )

--- a/src/ecosystem_analyzer/ecosystem_report.py
+++ b/src/ecosystem_analyzer/ecosystem_report.py
@@ -39,7 +39,7 @@ def process_diagnostics(
         flaky_runs = output.get("flaky_runs")
 
         # Count stable + flaky locations for the per-project limit
-        num_stable = len(output.get("diagnostics", []))
+        num_stable = len(output["diagnostics"])
         num_flaky_locs = len(output.get("flaky_diagnostics", []))
         num_diagnostics = num_stable + num_flaky_locs
 
@@ -55,7 +55,7 @@ def process_diagnostics(
         total_diagnostics += num_diagnostics
 
         # Add stable diagnostics
-        for diagnostic in output.get("diagnostics", []):
+        for diagnostic in output["diagnostics"]:
             all_diagnostics.append(_report_diagnostic(output, diagnostic))
 
         # Add flaky locations as entries with flaky metadata

--- a/src/ecosystem_analyzer/ecosystem_report.py
+++ b/src/ecosystem_analyzer/ecosystem_report.py
@@ -21,6 +21,9 @@ def _report_diagnostic(output: RunOutput, diagnostic: Diagnostic) -> ReportDiagn
         "level": diagnostic["level"],
         "lint_name": diagnostic["lint_name"],
         "message": diagnostic["message"],
+        "is_flaky": False,
+        "flaky_runs": output["flaky_runs"],
+        "variants": [],
     }
     if github_ref := diagnostic.get("github_ref"):
         report_diagnostic["github_ref"] = github_ref
@@ -36,11 +39,10 @@ def process_diagnostics(
     total_diagnostics = 0
     for output in data["outputs"]:
         project = output["project"]
-        flaky_runs = output.get("flaky_runs")
 
         # Count stable + flaky locations for the per-project limit
         num_stable = len(output["diagnostics"])
-        num_flaky_locs = len(output.get("flaky_diagnostics", []))
+        num_flaky_locs = len(output["flaky_diagnostics"])
         num_diagnostics = num_stable + num_flaky_locs
 
         if (
@@ -59,11 +61,10 @@ def process_diagnostics(
             all_diagnostics.append(_report_diagnostic(output, diagnostic))
 
         # Add flaky locations as entries with flaky metadata
-        for loc in output.get("flaky_diagnostics", []):
+        for loc in output["flaky_diagnostics"]:
             first_diagnostic = loc["variants"][0]["diagnostic"]
             entry = _report_diagnostic(output, first_diagnostic)
             entry["is_flaky"] = True
-            entry["flaky_runs"] = flaky_runs
             entry["variants"] = loc["variants"]
             all_diagnostics.append(entry)
 
@@ -160,7 +161,7 @@ def generate(
 
     flaky_project_names = set()
     for output in data["outputs"]:
-        if output.get("flaky_diagnostics"):
+        if output["flaky_diagnostics"]:
             flaky_project_names.add(output["project"])
 
     output_file = generate_html_report(

--- a/src/ecosystem_analyzer/flaky.py
+++ b/src/ecosystem_analyzer/flaky.py
@@ -1,5 +1,7 @@
 """Logic for detecting flaky diagnostics by comparing multiple ty runs."""
 
+from collections import Counter
+
 from .schema import (
     Diagnostic,
     DiagnosticKey,
@@ -42,7 +44,7 @@ def classify_diagnostics(
     assert n >= 2, "Need at least 2 runs to detect flakiness"
 
     # Count how many runs each diagnostic key appears in
-    key_counts: dict[DiagnosticKey, int] = {}
+    key_counts: Counter[DiagnosticKey] = Counter()
     # Keep one representative Diagnostic for each key
     key_to_diag: dict[DiagnosticKey, Diagnostic] = {}
 
@@ -53,7 +55,7 @@ def classify_diagnostics(
             key = _diagnostic_key(diag)
             if key not in seen_in_run:
                 seen_in_run.add(key)
-                key_counts[key] = key_counts.get(key, 0) + 1
+                key_counts[key] += 1
                 if key not in key_to_diag:
                     key_to_diag[key] = diag
 

--- a/src/ecosystem_analyzer/main.py
+++ b/src/ecosystem_analyzer/main.py
@@ -733,18 +733,22 @@ def parse_diagnostics(
     diagnostics = parser.parse(diagnostic_content)
     panic_messages = parser.parse_panic_messages(diagnostic_content)
 
-    exit_status = ExitStatus(return_code=return_code, count=1)
-    if panic_messages:
-        exit_status["panic_messages"] = [
+    exit_status: ExitStatus = {
+        "return_code": return_code,
+        "count": 1,
+        "panic_messages": [
             OutputVariant(message=message, count=1) for message in panic_messages
-        ]
+        ],
+    }
 
-    # Create output structure - only include fields that have meaningful values
+    # Include every required field in the output structure.
     run_output: RunOutput = {
         "project": project_name,
         "diagnostics": diagnostics,
         "exit_statuses": [exit_status],
         "median_time_s": None,
+        "flaky_runs": 0,
+        "flaky_diagnostics": [],
     }
 
     # Only include optional fields if they're provided

--- a/src/ecosystem_analyzer/schema.py
+++ b/src/ecosystem_analyzer/schema.py
@@ -37,7 +37,7 @@ class Diagnostic(SourceLocation):
 class ProjectMetadata(TypedDict, closed=True):
     """Optional classification metadata attached to an analyzed project."""
 
-    kind: NotRequired[str]
+    kind: str
 
 
 class ProjectIdentity(TypedDict):
@@ -78,7 +78,7 @@ class ExitStatus(TypedDict, closed=True):
 
     return_code: int | None
     count: int
-    panic_messages: NotRequired[list[OutputVariant]]
+    panic_messages: list[OutputVariant]
     stderr: NotRequired[list[OutputVariant]]
 
 
@@ -88,9 +88,10 @@ class RunOutput(ProjectIdentity, closed=True):
     project_location: NotRequired[str]
     ty_commit: NotRequired[str]
     diagnostics: list[Diagnostic]
-    flaky_diagnostics: NotRequired[list[FlakyLocation]]
+    flaky_diagnostics: list[FlakyLocation]
     exit_statuses: list[ExitStatus]
-    flaky_runs: NotRequired[int]  # Total number of runs used for flaky detection
+    flaky_runs: int
+    """Total number of runs used for flaky detection"""
     median_time_s: float | None
 
 
@@ -126,9 +127,9 @@ class HistoryData(TypedDict, closed=True):
 class ReportDiagnostic(Diagnostic, ProjectInfo, closed=True):
     """A project-qualified diagnostic prepared for HTML report rendering."""
 
-    is_flaky: NotRequired[bool]
-    flaky_runs: NotRequired[int | None]
-    variants: NotRequired[list[FlakyVariant]]
+    is_flaky: bool
+    flaky_runs: int
+    variants: list[FlakyVariant]
 
 
 class DiagnosticTextDiff(TypedDict, closed=True):
@@ -188,7 +189,7 @@ class FileDiffData(TypedDict, closed=True):
 class AnnotatedFlakyLocation(FlakyLocation, closed=True):
     """A flaky source location annotated with its observed run count."""
 
-    flaky_runs: int | None
+    flaky_runs: int
 
 
 class ChangedFlakyLocation(TypedDict, closed=True):
@@ -212,8 +213,8 @@ class AddedOrRemovedProjectDiff(ProjectInfo, closed=True):
     diagnostics: list[Diagnostic]
     exit_statuses: list[ExitStatus]
     exit_status_runs: int
-    flaky_diagnostics: NotRequired[list[FlakyLocation]]
-    flaky_runs: NotRequired[int | None]
+    flaky_diagnostics: list[FlakyLocation]
+    flaky_runs: int
 
 
 class ModifiedProjectDiff(ProjectInfo, closed=True):

--- a/src/ecosystem_analyzer/templates/diff.html
+++ b/src/ecosystem_analyzer/templates/diff.html
@@ -1026,7 +1026,7 @@
                 {% endfor %}
                 {# Flaky locations in this added file #}
                 {% if project.flaky_file_diffs is defined and file_data.path in project.flaky_file_diffs %}
-                {% for loc in project.flaky_file_diffs[file_data.path].get("added", []) %}
+                {% for loc in project.flaky_file_diffs[file_data.path].added %}
                 {{ render_flaky_location(loc, "added", project.project) }}
                 {% endfor %}
                 {% endif %}
@@ -1046,7 +1046,7 @@
                 {% endfor %}
                 {# Flaky locations in this removed file #}
                 {% if project.flaky_file_diffs is defined and file_data.path in project.flaky_file_diffs %}
-                {% for loc in project.flaky_file_diffs[file_data.path].get("removed", []) %}
+                {% for loc in project.flaky_file_diffs[file_data.path].removed %}
                 {{ render_flaky_location(loc, "removed", project.project) }}
                 {% endfor %}
                 {% endif %}
@@ -1109,13 +1109,13 @@
                 {# Flaky locations in this modified file #}
                 {% if project.flaky_file_diffs is defined and file_data.path in project.flaky_file_diffs %}
                 {% set ffd = project.flaky_file_diffs[file_data.path] %}
-                {% for loc in ffd.get("added", []) %}
+                {% for loc in ffd.added %}
                 {{ render_flaky_location(loc, "added", project.project) }}
                 {% endfor %}
-                {% for loc in ffd.get("removed", []) %}
+                {% for loc in ffd.removed %}
                 {{ render_flaky_location(loc, "removed", project.project) }}
                 {% endfor %}
-                {% for change in ffd.get("changed", []) %}
+                {% for change in ffd.changed %}
                 {{ render_flaky_changed(change, project.project) }}
                 {% endfor %}
                 {% endif %}
@@ -1126,9 +1126,9 @@
             {# Files that only have flaky changes (no stable diagnostic changes) #}
             {% if project.flaky_file_diffs is defined %}
             {% set stable_files = [] %}
-            {% for f in project.diffs.get("added_files", []) %}{% if stable_files.append(f.path) %}{% endif %}{% endfor %}
-            {% for f in project.diffs.get("removed_files", []) %}{% if stable_files.append(f.path) %}{% endif %}{% endfor %}
-            {% for f in project.diffs.get("modified_files", []) %}{% if stable_files.append(f.path) %}{% endif %}{% endfor %}
+            {% for f in project.diffs.added_files %}{% if stable_files.append(f.path) %}{% endif %}{% endfor %}
+            {% for f in project.diffs.removed_files %}{% if stable_files.append(f.path) %}{% endif %}{% endfor %}
+            {% for f in project.diffs.modified_files %}{% if stable_files.append(f.path) %}{% endif %}{% endfor %}
             {% for flaky_path, ffd in project.flaky_file_diffs.items()|sort %}
             {% if flaky_path not in stable_files %}
             <div class="file modified">
@@ -1136,13 +1136,13 @@
                     <h4 style="margin: 0;">{{ flaky_path }}</h4>
                     <button class="copy-btn" onclick="copyPath(this, '{{ flaky_path }}')">📋</button>
                 </div>
-                {% for loc in ffd.get("added", []) %}
+                {% for loc in ffd.added %}
                 {{ render_flaky_location(loc, "added", project.project) }}
                 {% endfor %}
-                {% for loc in ffd.get("removed", []) %}
+                {% for loc in ffd.removed %}
                 {{ render_flaky_location(loc, "removed", project.project) }}
                 {% endfor %}
-                {% for change in ffd.get("changed", []) %}
+                {% for change in ffd.changed %}
                 {{ render_flaky_changed(change, project.project) }}
                 {% endfor %}
             </div>

--- a/src/ecosystem_analyzer/templates/diff.html
+++ b/src/ecosystem_analyzer/templates/diff.html
@@ -680,7 +680,7 @@
     {% endif %}
 </div>
 {% set summarized_messages = namespace(remaining=summarized_panic_messages | list) %}
-{% for variant in status.get("panic_messages", []) %}
+{% for variant in status.panic_messages %}
 {% if variant.count == status.count and variant.message in summarized_messages.remaining %}
 {% set _ = summarized_messages.remaining.remove(variant.message) %}
 {% else %}
@@ -969,7 +969,7 @@
         {% if diffs.added_projects %}
         <h2>Added Projects</h2>
         {% for project in diffs.added_projects %}
-        <div class="project added"{% if project.project_metadata is defined and project.project_metadata.kind is defined %} data-project-kind="{{ project.project_metadata.kind }}"{% endif %}>
+        <div class="project added"{% if project.project_metadata is defined %} data-project-kind="{{ project.project_metadata.kind }}"{% endif %}>
             <h3>{{ project.project }} <small>(<a href="{{ project.project_location }}" target="_blank">{{ project.project_location }}</a>)</small></h3>
             <div style="margin-bottom: 12px;"><strong>Observed outcomes:</strong> {{ render_exit_statuses(project.exit_statuses, project.exit_status_runs) }}</div>
             {% set file_groups = project.diagnostics|groupby('path') %}
@@ -991,7 +991,7 @@
         {% if diffs.removed_projects %}
         <h2>Removed Projects</h2>
         {% for project in diffs.removed_projects %}
-        <div class="project removed"{% if project.project_metadata is defined and project.project_metadata.kind is defined %} data-project-kind="{{ project.project_metadata.kind }}"{% endif %}>
+        <div class="project removed"{% if project.project_metadata is defined %} data-project-kind="{{ project.project_metadata.kind }}"{% endif %}>
             <h3>{{ project.project }} <small>(<a href="{{ project.project_location }}" target="_blank">{{ project.project_location }}</a>)</small></h3>
             <div style="margin-bottom: 12px;"><strong>Observed outcomes:</strong> {{ render_exit_statuses(project.exit_statuses, project.exit_status_runs) }}</div>
             {% set file_groups = project.diagnostics|groupby('path') %}
@@ -1012,7 +1012,7 @@
 
         {% if diffs.modified_projects %}
         {% for project in diffs.modified_projects %}
-        <div class="project modified"{% if project.project_metadata is defined and project.project_metadata.kind is defined %} data-project-kind="{{ project.project_metadata.kind }}"{% endif %}>
+        <div class="project modified"{% if project.project_metadata is defined %} data-project-kind="{{ project.project_metadata.kind }}"{% endif %}>
             <h3>{{ project.project }} <small>(<a href="{{ project.project_location }}" target="_blank">{{ project.project_location }}</a>)</small></h3>
             {% if project.diffs.added_files %}
             {% for file_data in project.diffs.added_files %}

--- a/src/ecosystem_analyzer/templates/ecosystem_report.html
+++ b/src/ecosystem_analyzer/templates/ecosystem_report.html
@@ -296,7 +296,7 @@
         </thead>
         <tbody>
             {% for diagnostic in diagnostics %}
-            <tr class="diagnostic-row{% if diagnostic.is_flaky is defined and diagnostic.is_flaky %} is-flaky{% endif %}" data-project="{{ diagnostic.project }}" data-lint="{{ diagnostic.lint_name }}"
+            <tr class="diagnostic-row{% if diagnostic.is_flaky %} is-flaky{% endif %}" data-project="{{ diagnostic.project }}" data-lint="{{ diagnostic.lint_name }}"
                 data-level="{{ diagnostic.level }}">
                 <td>
                     {% if diagnostic.project_location %}
@@ -307,7 +307,7 @@
                 </td>
                 <td class="{{ diagnostic.level }}">
                     {{ diagnostic.lint_name }}
-                    {% if diagnostic.is_flaky is defined and diagnostic.is_flaky %}
+                    {% if diagnostic.is_flaky %}
                     <span class="flaky-badge" title="Flaky: nondeterministic across {{ diagnostic.flaky_runs }} runs">flaky</span>
                     {% endif %}
                 </td>
@@ -319,7 +319,7 @@
                     {% endif %}
                 </td>
                 <td>
-                    {% if diagnostic.is_flaky is defined and diagnostic.is_flaky %}
+                    {% if diagnostic.is_flaky %}
                         {% for v in diagnostic.variants %}
                         <div class="flaky-variant">
                             <span class="flaky-freq">({{ v.count }}/{{ diagnostic.flaky_runs }})</span>

--- a/src/ecosystem_analyzer/ty.py
+++ b/src/ecosystem_analyzer/ty.py
@@ -247,7 +247,7 @@ class Ty:
 
             if (
                 return_code in (0, 1)
-                and (time_s := output.get("median_time_s")) is not None
+                and (time_s := output["median_time_s"]) is not None
             ):
                 times.append(time_s)
 

--- a/src/ecosystem_analyzer/ty.py
+++ b/src/ecosystem_analyzer/ty.py
@@ -30,7 +30,7 @@ def _aggregate_panic_messages(statuses: list[ExitStatus]) -> list[OutputVariant]
     for status in statuses:
         messages = [
             variant["message"]
-            for variant in status.get("panic_messages", [])
+            for variant in status["panic_messages"]
             for _ in range(variant["count"])
         ]
         indexed_by_run.append(index_panic_messages(messages))
@@ -203,11 +203,14 @@ class Ty:
             stderr = None
             panic_messages = []
 
-        exit_status = ExitStatus(return_code=return_code, count=1)
-        if panic_messages:
-            exit_status["panic_messages"] = [
+        exit_status: ExitStatus = {
+            "return_code": return_code,
+            "count": 1,
+            "panic_messages": [
                 OutputVariant(message=message, count=1) for message in panic_messages
-            ]
+            ],
+        }
+
         if stderr:
             exit_status["stderr"] = [OutputVariant(message=stderr, count=1)]
 
@@ -218,6 +221,8 @@ class Ty:
             "diagnostics": diagnostics,
             "exit_statuses": [exit_status],
             "median_time_s": execution_time,
+            "flaky_runs": 0,
+            "flaky_diagnostics": [],
         })
 
     def run_on_project_multiple(self, project: InstalledProject, n: int) -> RunOutput:
@@ -265,9 +270,11 @@ class Ty:
             statuses_by_return_code.items(),
             key=lambda item: (item[0] is None, item[0] or 0),
         ):
-            exit_status = ExitStatus(return_code=return_code, count=len(statuses))
-            if panic_messages := _aggregate_panic_messages(statuses):
-                exit_status["panic_messages"] = panic_messages
+            exit_status = ExitStatus(
+                return_code=return_code,
+                count=len(statuses),
+                panic_messages=_aggregate_panic_messages(statuses),
+            )
             if stderr := _aggregate_stderr(statuses):
                 exit_status["stderr"] = stderr
             exit_statuses.append(exit_status)
@@ -280,10 +287,8 @@ class Ty:
             "flaky_runs": n,
             "exit_statuses": exit_statuses,
             "median_time_s": median_time,
+            "flaky_diagnostics": flaky_locations,
         })
-
-        if flaky_locations:
-            result["flaky_diagnostics"] = flaky_locations
 
         flaky_count = sum(len(loc["variants"]) for loc in flaky_locations)
         logger.info(

--- a/tests/test_json_roundtrip.py
+++ b/tests/test_json_roundtrip.py
@@ -20,7 +20,7 @@ def _make_output(
     project: str,
     diagnostics: list[Diagnostic],
     flaky_diagnostics: list[FlakyLocation] | None = None,
-    flaky_runs: int | None = None,
+    flaky_runs: int = 0,
     exit_statuses: list[ExitStatus] | None = None,
     panic_messages: list[str] | None = None,
     stderr: str | None = None,
@@ -30,12 +30,14 @@ def _make_output(
 ) -> RunOutput:
     run_count = flaky_runs or 1
     if exit_statuses is None:
-        exit_status = ExitStatus(return_code=return_code, count=run_count)
-        if panic_messages is not None:
-            exit_status["panic_messages"] = [
+        exit_status: ExitStatus = {
+            "return_code": return_code,
+            "count": run_count,
+            "panic_messages": [
                 OutputVariant(message=message, count=run_count)
-                for message in panic_messages
-            ]
+                for message in panic_messages or []
+            ],
+        }
         if stderr is not None:
             exit_status["stderr"] = [OutputVariant(message=stderr, count=run_count)]
         exit_statuses = [exit_status]
@@ -47,11 +49,9 @@ def _make_output(
         "diagnostics": diagnostics,
         "exit_statuses": exit_statuses,
         "median_time_s": time_s,
+        "flaky_runs": flaky_runs,
+        "flaky_diagnostics": flaky_diagnostics or [],
     }
-    if flaky_diagnostics is not None:
-        entry["flaky_diagnostics"] = flaky_diagnostics
-    if flaky_runs is not None:
-        entry["flaky_runs"] = flaky_runs
     if project_metadata is not None:
         entry["project_metadata"] = project_metadata
     return entry
@@ -889,7 +889,7 @@ info: Args: /tmp/new_commit/ty check ."""
                     [],
                     flaky_runs=3,
                     exit_statuses=[
-                        {"return_code": 1, "count": 1},
+                        {"return_code": 1, "count": 1, "panic_messages": []},
                         {
                             "return_code": 2,
                             "count": 2,
@@ -933,8 +933,8 @@ info: Args: /tmp/new_commit/ty check ."""
                     [],
                     flaky_runs=3,
                     exit_statuses=[
-                        {"return_code": 1, "count": 2},
-                        {"return_code": None, "count": 1},
+                        {"return_code": 1, "count": 2, "panic_messages": []},
+                        {"return_code": None, "count": 1, "panic_messages": []},
                     ],
                     return_code=1,
                 )
@@ -954,8 +954,8 @@ info: Args: /tmp/new_commit/ty check ."""
                     [],
                     flaky_runs=3,
                     exit_statuses=[
-                        {"return_code": 1, "count": 1},
-                        {"return_code": 2, "count": 2},
+                        {"return_code": 1, "count": 1, "panic_messages": []},
+                        {"return_code": 2, "count": 2, "panic_messages": []},
                     ],
                     return_code=1,
                 )
@@ -974,8 +974,8 @@ info: Args: /tmp/new_commit/ty check ."""
                     [],
                     flaky_runs=3,
                     exit_statuses=[
-                        {"return_code": 1, "count": 2},
-                        {"return_code": 2, "count": 1},
+                        {"return_code": 1, "count": 2, "panic_messages": []},
+                        {"return_code": 2, "count": 1, "panic_messages": []},
                     ],
                     return_code=1,
                 )
@@ -996,8 +996,8 @@ info: Args: /tmp/new_commit/ty check ."""
                     [],
                     flaky_runs=3,
                     exit_statuses=[
-                        {"return_code": 2, "count": 2},
-                        {"return_code": 3, "count": 1},
+                        {"return_code": 2, "count": 2, "panic_messages": []},
+                        {"return_code": 3, "count": 1, "panic_messages": []},
                     ],
                     time_s=None,
                     return_code=2,
@@ -1030,6 +1030,7 @@ info: Args: /tmp/new_commit/ty check ."""
                         {
                             "return_code": -6,
                             "count": 10,
+                            "panic_messages": [],
                             "stderr": stack_overflows,
                         }
                     ],
@@ -1046,12 +1047,12 @@ info: Args: /tmp/new_commit/ty check ."""
 
     def test_varying_failure_codes_on_both_sides_are_persistent(self) -> None:
         old_statuses: list[ExitStatus] = [
-            {"return_code": 2, "count": 2},
-            {"return_code": 3, "count": 1},
+            {"return_code": 2, "count": 2, "panic_messages": []},
+            {"return_code": 3, "count": 1, "panic_messages": []},
         ]
         new_statuses: list[ExitStatus] = [
-            {"return_code": 2, "count": 1},
-            {"return_code": 3, "count": 2},
+            {"return_code": 2, "count": 1, "panic_messages": []},
+            {"return_code": 3, "count": 2, "panic_messages": []},
         ]
         diff = _make_diff(
             [
@@ -1101,8 +1102,8 @@ info: Args: /tmp/new_commit/ty check ."""
                     [old_diagnostic, new_diagnostic],
                     flaky_runs=3,
                     exit_statuses=[
-                        {"return_code": 1, "count": 2},
-                        {"return_code": 2, "count": 1},
+                        {"return_code": 1, "count": 2, "panic_messages": []},
+                        {"return_code": 2, "count": 1, "panic_messages": []},
                     ],
                     return_code=1,
                 )
@@ -1117,11 +1118,12 @@ info: Args: /tmp/new_commit/ty check ."""
             [],
             flaky_runs=3,
             exit_statuses=[
-                {"return_code": 1, "count": 2},
+                {"return_code": 1, "count": 2, "panic_messages": []},
                 {
                     "return_code": 2,
                     "count": 1,
                     "stderr": [{"message": "new project crashed", "count": 1}],
+                    "panic_messages": [],
                 },
             ],
         )
@@ -1140,11 +1142,12 @@ info: Args: /tmp/new_commit/ty check ."""
             [],
             flaky_runs=3,
             exit_statuses=[
-                {"return_code": 1, "count": 2},
+                {"return_code": 1, "count": 2, "panic_messages": []},
                 {
                     "return_code": None,
                     "count": 1,
                     "stderr": [{"message": "old project timed out", "count": 1}],
+                    "panic_messages": [],
                 },
             ],
         )
@@ -1159,7 +1162,7 @@ info: Args: /tmp/new_commit/ty check ."""
 
     def test_flaky_exit_evidence_changes_with_same_statuses_are_preserved(self) -> None:
         old_statuses: list[ExitStatus] = [
-            {"return_code": 1, "count": 2},
+            {"return_code": 1, "count": 2, "panic_messages": []},
             {
                 "return_code": 2,
                 "count": 1,
@@ -1168,7 +1171,7 @@ info: Args: /tmp/new_commit/ty check ."""
             },
         ]
         new_statuses: list[ExitStatus] = [
-            {"return_code": 1, "count": 2},
+            {"return_code": 1, "count": 2, "panic_messages": []},
             {
                 "return_code": 2,
                 "count": 1,
@@ -1266,12 +1269,12 @@ info: Args: /tmp/new_commit/ty check ."""
 
     def test_flaky_exit_frequency_changes_are_ignored(self) -> None:
         old_statuses: list[ExitStatus] = [
-            {"return_code": 1, "count": 9},
-            {"return_code": 2, "count": 1},
+            {"return_code": 1, "count": 9, "panic_messages": []},
+            {"return_code": 2, "count": 1, "panic_messages": []},
         ]
         new_statuses: list[ExitStatus] = [
-            {"return_code": 1, "count": 1},
-            {"return_code": 2, "count": 9},
+            {"return_code": 1, "count": 1, "panic_messages": []},
+            {"return_code": 2, "count": 9, "panic_messages": []},
         ]
         diff = _make_diff(
             [_make_output("proj", [], flaky_runs=10, exit_statuses=old_statuses)],

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -70,7 +70,9 @@ def test_parse_diagnostics_preserves_empty_output_exit_status(tmp_path: Path) ->
     assert result.exit_code == 0, result.output
     [run_output] = json.loads(output.read_text())["outputs"]
     assert run_output["diagnostics"] == []
-    assert run_output["exit_statuses"] == [{"return_code": 101, "count": 1}]
+    assert run_output["exit_statuses"] == [
+        {"return_code": 101, "count": 1, "panic_messages": []}
+    ]
 
 
 def test_statistics_skip_missing_timings_from_parsed_diagnostics(

--- a/tests/test_ty.py
+++ b/tests/test_ty.py
@@ -14,11 +14,13 @@ def _output(
     panic_messages: list[str] | None = None,
     stderr: str | None = None,
 ) -> RunOutput:
-    exit_status = ExitStatus(return_code=return_code, count=1)
-    if panic_messages:
-        exit_status["panic_messages"] = [
-            OutputVariant(message=message, count=1) for message in panic_messages
-        ]
+    exit_status: ExitStatus = {
+        "return_code": return_code,
+        "count": 1,
+        "panic_messages": [
+            OutputVariant(message=message, count=1) for message in panic_messages or []
+        ],
+    }
     if stderr:
         exit_status["stderr"] = [OutputVariant(message=stderr, count=1)]
     output = RunOutput({
@@ -28,6 +30,8 @@ def _output(
         "diagnostics": diagnostics or [],
         "exit_statuses": [exit_status],
         "median_time_s": time_s,
+        "flaky_runs": 0,
+        "flaky_diagnostics": [],
     })
     return output
 
@@ -66,7 +70,7 @@ def test_multiple_runs_classify_intermittent_abnormal_exit_as_flaky() -> None:
 
     assert run.call_count == 3
     assert result["exit_statuses"] == [
-        {"return_code": 1, "count": 2},
+        {"return_code": 1, "count": 2, "panic_messages": []},
         {
             "return_code": 2,
             "count": 1,
@@ -95,8 +99,8 @@ def test_multiple_runs_classify_intermittent_timeout_as_flaky() -> None:
 
     assert run.call_count == 3
     assert result["exit_statuses"] == [
-        {"return_code": 1, "count": 2},
-        {"return_code": None, "count": 1},
+        {"return_code": 1, "count": 2, "panic_messages": []},
+        {"return_code": None, "count": 1, "panic_messages": []},
     ]
 
 
@@ -132,7 +136,9 @@ def test_multiple_runs_preserve_stable_timeout() -> None:
     with patch.object(ty, "run_on_project", side_effect=[_output(None)] * 3):
         result = ty.run_on_project_multiple(_project(), 3)
 
-    assert result["exit_statuses"] == [{"return_code": None, "count": 3}]
+    assert result["exit_statuses"] == [
+        {"return_code": None, "count": 3, "panic_messages": []}
+    ]
     assert result["median_time_s"] is None
 
 
@@ -148,6 +154,6 @@ def test_multiple_runs_preserve_mixed_status_frequencies() -> None:
         result = ty.run_on_project_multiple(_project(), 3)
 
     assert result["exit_statuses"] == [
-        {"return_code": 1, "count": 1},
-        {"return_code": 2, "count": 2},
+        {"return_code": 1, "count": 1, "panic_messages": []},
+        {"return_code": 2, "count": 2, "panic_messages": []},
     ]


### PR DESCRIPTION
## Summary

- Require consistently present fields in ecosystem run, exit-status, project-metadata, and report TypedDict schemas.
- Initialize those fields at producer boundaries and access them directly throughout diagnostic comparison and HTML rendering.
- Simplify diagnostic counting with `Counter` and generator-based totals while preserving guards for genuinely optional data.