### PR TITLE
Analyze half of ecosystem projects with strict ty settings

### DIFF
--- a/src/ecosystem_analyzer/diff.py
+++ b/src/ecosystem_analyzer/diff.py
@@ -27,7 +27,6 @@ from .schema import (
     FailureStatus,
     FileDiffData,
     FlakyDiagnosticDiffData,
-    FlakyExitStatusChange,
     FlakyLocation,
     FlakyVariant,
     LargeTimingChange,
@@ -526,16 +525,15 @@ class DiagnosticDiff:
                 old_project, new_project
             )
             if flaky_exit_status_change:
-                flaky_project: FlakyExitStatusChange = {
+                result["flaky_exit_status_changes"].append({
                     "project": project_name,
                     "project_location": new_project.get("project_location", ""),
+                    "strict_settings": new_project["strict_settings"],
                     "old": flaky_exit_status_change["old"],
                     "new": flaky_exit_status_change["new"],
                     "old_runs": flaky_exit_status_change["old_runs"],
                     "new_runs": flaky_exit_status_change["new_runs"],
-                }
-                self._add_project_details(flaky_project, new_project)
-                result["flaky_exit_status_changes"].append(flaky_project)
+                })
 
             old_panics = self._stable_panic_messages(old_project)
             new_panics = self._stable_panic_messages(new_project)
@@ -596,6 +594,7 @@ class DiagnosticDiff:
                 failed_project: FailedProjectDiff = {
                     "project": project_name,
                     "project_location": new_project.get("project_location", ""),
+                    "strict_settings": new_project["strict_settings"],
                     "old_status": old_status.value,
                     "new_status": new_status.value,
                     "old_exit_statuses": self._exit_statuses(old_project),
@@ -611,7 +610,7 @@ class DiagnosticDiff:
                     "new_persistent_panic_messages": new_persistent_panics,
                     "failure_status": failure_status,
                 }
-                self._add_project_details(failed_project, new_project)
+                self._add_project_kind(failed_project, new_project)
                 result["failed_projects"].append(failed_project)
                 # Skip detailed diff analysis for failed projects
                 continue
@@ -633,24 +632,24 @@ class DiagnosticDiff:
                 removed_project: AddedOrRemovedProjectDiff = {
                     "project": project_name,
                     "project_location": project_data.get("project_location", ""),
+                    "strict_settings": project_data["strict_settings"],
                     "diagnostics": diagnostics,
                     "exit_statuses": self._exit_statuses(project_data),
                     "exit_status_runs": self._total_runs(project_data),
                     "flaky_diagnostics": project_data["flaky_diagnostics"],
                     "flaky_runs": project_data["flaky_runs"],
                 }
-                self._add_project_details(removed_project, project_data)
+                self._add_project_kind(removed_project, project_data)
                 if len(self._exit_statuses(project_data)) > 1:
-                    removed_flaky_project: FlakyExitStatusChange = {
+                    result["flaky_exit_status_changes"].append({
                         "project": project_name,
                         "project_location": project_data.get("project_location", ""),
+                        "strict_settings": project_data["strict_settings"],
                         "old": self._exit_statuses(project_data),
                         "new": [],
                         "old_runs": self._total_runs(project_data),
                         "new_runs": 0,
-                    }
-                    self._add_project_details(removed_flaky_project, project_data)
-                    result["flaky_exit_status_changes"].append(removed_flaky_project)
+                    })
                 result["removed_projects"].append(removed_project)
 
         # Find added projects
@@ -670,24 +669,24 @@ class DiagnosticDiff:
                 added_project: AddedOrRemovedProjectDiff = {
                     "project": project_name,
                     "project_location": project_data.get("project_location", ""),
+                    "strict_settings": project_data["strict_settings"],
                     "diagnostics": diagnostics,
                     "exit_statuses": self._exit_statuses(project_data),
                     "exit_status_runs": self._total_runs(project_data),
                     "flaky_diagnostics": project_data["flaky_diagnostics"],
                     "flaky_runs": project_data["flaky_runs"],
                 }
-                self._add_project_details(added_project, project_data)
+                self._add_project_kind(added_project, project_data)
                 if len(self._exit_statuses(project_data)) > 1:
-                    added_flaky_project: FlakyExitStatusChange = {
+                    result["flaky_exit_status_changes"].append({
                         "project": project_name,
                         "project_location": project_data.get("project_location", ""),
+                        "strict_settings": project_data["strict_settings"],
                         "old": [],
                         "new": self._exit_statuses(project_data),
                         "old_runs": 0,
                         "new_runs": self._total_runs(project_data),
-                    }
-                    self._add_project_details(added_flaky_project, project_data)
-                    result["flaky_exit_status_changes"].append(added_flaky_project)
+                    })
                 result["added_projects"].append(added_project)
 
         # Get list of failed projects to exclude from detailed analysis
@@ -761,9 +760,10 @@ class DiagnosticDiff:
                 modified_project: ModifiedProjectDiff = {
                     "project": project_name,
                     "project_location": new_project.get("project_location", ""),
+                    "strict_settings": new_project["strict_settings"],
                     "diffs": file_diffs,
                 }
-                self._add_project_details(modified_project, new_project)
+                self._add_project_kind(modified_project, new_project)
                 if has_flaky_changes:
                     modified_project["flaky_diffs"] = flaky_diffs
                     modified_project["flaky_file_diffs"] = (
@@ -811,11 +811,9 @@ class DiagnosticDiff:
         return metadata["kind"] if metadata is not None else None
 
     @classmethod
-    def _add_project_details(cls, entry: ProjectInfo, output: RunOutput) -> None:
+    def _add_project_kind(cls, entry: ProjectInfo, output: RunOutput) -> None:
         if kind := cls._project_kind(output):
             entry["project_metadata"] = {"kind": kind}
-        if "strict_settings" in output:
-            entry["strict_settings"] = output["strict_settings"]
 
     def _group_diagnostics_by_file(
         self, diagnostics: list[Diagnostic]
@@ -1857,7 +1855,6 @@ class DiagnosticDiff:
             "project_strictness": {
                 output["project"]: output["strict_settings"]
                 for output in chain(self.old_data["outputs"], self.new_data["outputs"])
-                if "strict_settings" in output
             },
             "project_kinds": sorted({
                 kind

--- a/src/ecosystem_analyzer/diff.py
+++ b/src/ecosystem_analyzer/diff.py
@@ -27,6 +27,7 @@ from .schema import (
     FailureStatus,
     FileDiffData,
     FlakyDiagnosticDiffData,
+    FlakyExitStatusChange,
     FlakyLocation,
     FlakyVariant,
     LargeTimingChange,
@@ -525,14 +526,16 @@ class DiagnosticDiff:
                 old_project, new_project
             )
             if flaky_exit_status_change:
-                result["flaky_exit_status_changes"].append({
+                flaky_project: FlakyExitStatusChange = {
                     "project": project_name,
                     "project_location": new_project.get("project_location", ""),
                     "old": flaky_exit_status_change["old"],
                     "new": flaky_exit_status_change["new"],
                     "old_runs": flaky_exit_status_change["old_runs"],
                     "new_runs": flaky_exit_status_change["new_runs"],
-                })
+                }
+                self._add_project_details(flaky_project, new_project)
+                result["flaky_exit_status_changes"].append(flaky_project)
 
             old_panics = self._stable_panic_messages(old_project)
             new_panics = self._stable_panic_messages(new_project)
@@ -608,7 +611,7 @@ class DiagnosticDiff:
                     "new_persistent_panic_messages": new_persistent_panics,
                     "failure_status": failure_status,
                 }
-                self._add_project_kind(failed_project, new_project)
+                self._add_project_details(failed_project, new_project)
                 result["failed_projects"].append(failed_project)
                 # Skip detailed diff analysis for failed projects
                 continue
@@ -636,16 +639,18 @@ class DiagnosticDiff:
                     "flaky_diagnostics": project_data["flaky_diagnostics"],
                     "flaky_runs": project_data["flaky_runs"],
                 }
-                self._add_project_kind(removed_project, project_data)
+                self._add_project_details(removed_project, project_data)
                 if len(self._exit_statuses(project_data)) > 1:
-                    result["flaky_exit_status_changes"].append({
+                    removed_flaky_project: FlakyExitStatusChange = {
                         "project": project_name,
                         "project_location": project_data.get("project_location", ""),
                         "old": self._exit_statuses(project_data),
                         "new": [],
                         "old_runs": self._total_runs(project_data),
                         "new_runs": 0,
-                    })
+                    }
+                    self._add_project_details(removed_flaky_project, project_data)
+                    result["flaky_exit_status_changes"].append(removed_flaky_project)
                 result["removed_projects"].append(removed_project)
 
         # Find added projects
@@ -671,16 +676,18 @@ class DiagnosticDiff:
                     "flaky_diagnostics": project_data["flaky_diagnostics"],
                     "flaky_runs": project_data["flaky_runs"],
                 }
-                self._add_project_kind(added_project, project_data)
+                self._add_project_details(added_project, project_data)
                 if len(self._exit_statuses(project_data)) > 1:
-                    result["flaky_exit_status_changes"].append({
+                    added_flaky_project: FlakyExitStatusChange = {
                         "project": project_name,
                         "project_location": project_data.get("project_location", ""),
                         "old": [],
                         "new": self._exit_statuses(project_data),
                         "old_runs": 0,
                         "new_runs": self._total_runs(project_data),
-                    })
+                    }
+                    self._add_project_details(added_flaky_project, project_data)
+                    result["flaky_exit_status_changes"].append(added_flaky_project)
                 result["added_projects"].append(added_project)
 
         # Get list of failed projects to exclude from detailed analysis
@@ -756,7 +763,7 @@ class DiagnosticDiff:
                     "project_location": new_project.get("project_location", ""),
                     "diffs": file_diffs,
                 }
-                self._add_project_kind(modified_project, new_project)
+                self._add_project_details(modified_project, new_project)
                 if has_flaky_changes:
                     modified_project["flaky_diffs"] = flaky_diffs
                     modified_project["flaky_file_diffs"] = (
@@ -804,9 +811,11 @@ class DiagnosticDiff:
         return metadata["kind"] if metadata is not None else None
 
     @classmethod
-    def _add_project_kind(cls, entry: ProjectInfo, output: RunOutput) -> None:
+    def _add_project_details(cls, entry: ProjectInfo, output: RunOutput) -> None:
         if kind := cls._project_kind(output):
             entry["project_metadata"] = {"kind": kind}
+        if "strict_settings" in output:
+            entry["strict_settings"] = output["strict_settings"]
 
     def _group_diagnostics_by_file(
         self, diagnostics: list[Diagnostic]
@@ -1845,6 +1854,11 @@ class DiagnosticDiff:
             "failure_descriptor": _failure_descriptor,
             "failure_status_labels": _FAILURE_STATUS_LABELS,
             "failure_status_titles": _FAILURE_STATUS_TITLES,
+            "project_strictness": {
+                output["project"]: output["strict_settings"]
+                for output in chain(self.old_data["outputs"], self.new_data["outputs"])
+                if "strict_settings" in output
+            },
             "project_kinds": sorted({
                 kind
                 for output in chain(self.old_data["outputs"], self.new_data["outputs"])

--- a/src/ecosystem_analyzer/ecosystem_report.py
+++ b/src/ecosystem_analyzer/ecosystem_report.py
@@ -15,6 +15,7 @@ def _report_diagnostic(output: RunOutput, diagnostic: Diagnostic) -> ReportDiagn
     report_diagnostic: ReportDiagnostic = {
         "project": output["project"],
         "project_location": output.get("project_location", ""),
+        "strict_settings": output["strict_settings"],
         "path": diagnostic["path"],
         "line": diagnostic["line"],
         "column": diagnostic["column"],
@@ -27,8 +28,6 @@ def _report_diagnostic(output: RunOutput, diagnostic: Diagnostic) -> ReportDiagn
     }
     if github_ref := diagnostic.get("github_ref"):
         report_diagnostic["github_ref"] = github_ref
-    if "strict_settings" in output:
-        report_diagnostic["strict_settings"] = output["strict_settings"]
     return report_diagnostic
 
 
@@ -88,7 +87,6 @@ def generate_html_report(
     project_strictness = {
         diagnostic["project"]: diagnostic["strict_settings"]
         for diagnostic in diagnostics
-        if "strict_settings" in diagnostic
     }
     all_projects = sorted({d["project"] for d in diagnostics})
     lints = sorted({d["lint_name"] for d in diagnostics})

--- a/src/ecosystem_analyzer/ecosystem_report.py
+++ b/src/ecosystem_analyzer/ecosystem_report.py
@@ -27,6 +27,8 @@ def _report_diagnostic(output: RunOutput, diagnostic: Diagnostic) -> ReportDiagn
     }
     if github_ref := diagnostic.get("github_ref"):
         report_diagnostic["github_ref"] = github_ref
+    if "strict_settings" in output:
+        report_diagnostic["strict_settings"] = output["strict_settings"]
     return report_diagnostic
 
 
@@ -83,6 +85,11 @@ def generate_html_report(
     if flaky_project_names is None:
         flaky_project_names = set()
 
+    project_strictness = {
+        diagnostic["project"]: diagnostic["strict_settings"]
+        for diagnostic in diagnostics
+        if "strict_settings" in diagnostic
+    }
     all_projects = sorted({d["project"] for d in diagnostics})
     lints = sorted({d["lint_name"] for d in diagnostics})
     levels = sorted({d["level"] for d in diagnostics})
@@ -126,6 +133,7 @@ def generate_html_report(
         levels=levels,
         ty_commit=ty_commit,
         flaky_project_names=sorted_flaky_project_names,
+        project_strictness=project_strictness,
     )
 
     # Write output file

--- a/src/ecosystem_analyzer/main.py
+++ b/src/ecosystem_analyzer/main.py
@@ -744,6 +744,7 @@ def parse_diagnostics(
     # Include every required field in the output structure.
     run_output: RunOutput = {
         "project": project_name,
+        "strict_settings": False,
         "diagnostics": diagnostics,
         "exit_statuses": [exit_status],
         "median_time_s": None,

--- a/src/ecosystem_analyzer/schema.py
+++ b/src/ecosystem_analyzer/schema.py
@@ -45,7 +45,7 @@ class ProjectIdentity(TypedDict):
 
     project: str
     project_metadata: NotRequired[ProjectMetadata]
-    strict_settings: NotRequired[bool]
+    strict_settings: bool
 
 
 class ProjectInfo(ProjectIdentity):

--- a/src/ecosystem_analyzer/schema.py
+++ b/src/ecosystem_analyzer/schema.py
@@ -45,6 +45,7 @@ class ProjectIdentity(TypedDict):
 
     project: str
     project_metadata: NotRequired[ProjectMetadata]
+    strict_settings: NotRequired[bool]
 
 
 class ProjectInfo(ProjectIdentity):

--- a/src/ecosystem_analyzer/templates/diff.html
+++ b/src/ecosystem_analyzer/templates/diff.html
@@ -644,10 +644,8 @@
 </head>
 
 {% macro render_analysis_mode(project_name) %}
-{% if project_name in project_strictness %}
 {% set strict = project_strictness[project_name] %}
 <span class="analysis-mode analysis-mode-{{ 'strict' if strict else 'default' }}" title="Strict equality semantics and strict generic narrowing {{ 'enabled' if strict else 'disabled' }}">{{ 'strict' if strict else 'non-strict' }}</span>
-{% endif %}
 {% endmacro %}
 
 {% macro render_diagnostic(diag, change_type, project_name) %}
@@ -838,7 +836,7 @@
                     <option value="all">All Projects</option>
                     {% if statistics.merged_by_project %}
                     {% for project_data in statistics.merged_by_project %}
-                    <option value="{{ project_data.project_name }}">{{ project_data.project_name }}{% if project_data.project_name in project_strictness %} ({{ 'strict' if project_strictness[project_data.project_name] else 'non-strict' }}){% endif %} (-{{ project_data.removed }} +{{ project_data.added }} ~{{ project_data.changed }})</option>
+                    <option value="{{ project_data.project_name }}">{{ project_data.project_name }} ({{ 'strict' if project_strictness[project_data.project_name] else 'non-strict' }}) (-{{ project_data.removed }} +{{ project_data.added }} ~{{ project_data.changed }})</option>
                     {% endfor %}
                     {% endif %}
                 </select>

--- a/src/ecosystem_analyzer/templates/diff.html
+++ b/src/ecosystem_analyzer/templates/diff.html
@@ -161,6 +161,25 @@
             cursor: help;
         }
 
+        .analysis-mode {
+            display: inline-block;
+            font-size: 11px;
+            font-weight: 600;
+            padding: 2px 6px;
+            border-radius: 4px;
+            margin-left: 6px;
+        }
+
+        .analysis-mode-strict {
+            color: var(--flare);
+            background: rgba(99, 64, 172, 0.12);
+        }
+
+        .analysis-mode-default {
+            color: var(--rock);
+            background: rgba(120, 135, 110, 0.12);
+        }
+
         .diag-grid {
             display: grid;
             grid-template-columns: auto 1fr;
@@ -624,6 +643,13 @@
     </style>
 </head>
 
+{% macro render_analysis_mode(project_name) %}
+{% if project_name in project_strictness %}
+{% set strict = project_strictness[project_name] %}
+<span class="analysis-mode analysis-mode-{{ 'strict' if strict else 'default' }}" title="Strict equality semantics and strict generic narrowing {{ 'enabled' if strict else 'disabled' }}">{{ 'strict' if strict else 'non-strict' }}</span>
+{% endif %}
+{% endmacro %}
+
 {% macro render_diagnostic(diag, change_type, project_name) %}
 <div class="diagnostic {{ change_type }}" data-change-type="{{ change_type }}" data-lint-name="{{ diag.lint_name }}" data-project-name="{{ project_name }}">
     <div class="diag-grid">
@@ -762,7 +788,7 @@
                             </tr>
                             {% for project_data in statistics.merged_by_project[:20] %}
                             <tr>
-                                <td>{{ project_data.project_name }}{% if project_data.is_flaky %} <span class="flaky-badge" title="Flaky: nondeterministic diagnostics across multiple runs">flaky</span>{% endif %}</td>
+                                <td>{{ project_data.project_name }}{{ render_analysis_mode(project_data.project_name) }}{% if project_data.is_flaky %} <span class="flaky-badge" title="Flaky: nondeterministic diagnostics across multiple runs">flaky</span>{% endif %}</td>
                                 <td class="removed-col">{{ project_data.removed }}</td>
                                 <td class="added-col">{{ project_data.added }}</td>
                                 <td class="changed-col">{{ project_data.changed }}</td>
@@ -771,7 +797,7 @@
                             {% if statistics.merged_by_project|length > 20 %}
                             {% for project_data in statistics.merged_by_project[20:] %}
                             <tr class="project-row-hidden" style="display: none;">
-                                <td>{{ project_data.project_name }}{% if project_data.is_flaky %} <span class="flaky-badge" title="Flaky: nondeterministic diagnostics across multiple runs">flaky</span>{% endif %}</td>
+                                <td>{{ project_data.project_name }}{{ render_analysis_mode(project_data.project_name) }}{% if project_data.is_flaky %} <span class="flaky-badge" title="Flaky: nondeterministic diagnostics across multiple runs">flaky</span>{% endif %}</td>
                                 <td class="removed-col">{{ project_data.removed }}</td>
                                 <td class="added-col">{{ project_data.added }}</td>
                                 <td class="changed-col">{{ project_data.changed }}</td>
@@ -812,7 +838,7 @@
                     <option value="all">All Projects</option>
                     {% if statistics.merged_by_project %}
                     {% for project_data in statistics.merged_by_project %}
-                    <option value="{{ project_data.project_name }}">{{ project_data.project_name }} (-{{ project_data.removed }} +{{ project_data.added }} ~{{ project_data.changed }})</option>
+                    <option value="{{ project_data.project_name }}">{{ project_data.project_name }}{% if project_data.project_name in project_strictness %} ({{ 'strict' if project_strictness[project_data.project_name] else 'non-strict' }}){% endif %} (-{{ project_data.removed }} +{{ project_data.added }} ~{{ project_data.changed }})</option>
                     {% endfor %}
                     {% endif %}
                 </select>
@@ -869,7 +895,7 @@
                     {% set new_summarized_panic_messages = project.introduced_panic_messages + project.new_persistent_panic_messages %}
                     <tr class="failed-row-{{ failure_status }}" style="border-bottom: 1px solid rgba(38, 18, 48, 0.1);">
                         <td style="padding: 12px;">
-                            <strong>{{ project.project }}</strong>
+                            <strong>{{ project.project }}</strong>{{ render_analysis_mode(project.project) }}
                             <br><small><a href="{{ project.project_location }}" target="_blank">{{ project.project_location }}</a></small>
                         </td>
                         <td style="padding: 12px; text-align: center; font-weight: 600;">
@@ -953,7 +979,7 @@
                     {% for project in diffs.flaky_exit_status_changes %}
                     <tr style="border-bottom: 1px solid rgba(38, 18, 48, 0.1);">
                         <td style="padding: 12px;">
-                            <strong>{{ project.project }}</strong>
+                            <strong>{{ project.project }}</strong>{{ render_analysis_mode(project.project) }}
                             <span class="flaky-badge" title="Exit status varied across repeated runs">flaky</span>
                             <br><small><a href="{{ project.project_location }}" target="_blank">{{ project.project_location }}</a></small>
                         </td>
@@ -970,7 +996,7 @@
         <h2>Added Projects</h2>
         {% for project in diffs.added_projects %}
         <div class="project added"{% if project.project_metadata is defined %} data-project-kind="{{ project.project_metadata.kind }}"{% endif %}>
-            <h3>{{ project.project }} <small>(<a href="{{ project.project_location }}" target="_blank">{{ project.project_location }}</a>)</small></h3>
+            <h3>{{ project.project }}{{ render_analysis_mode(project.project) }} <small>(<a href="{{ project.project_location }}" target="_blank">{{ project.project_location }}</a>)</small></h3>
             <div style="margin-bottom: 12px;"><strong>Observed outcomes:</strong> {{ render_exit_statuses(project.exit_statuses, project.exit_status_runs) }}</div>
             {% set file_groups = project.diagnostics|groupby('path') %}
             {% for path, diagnostics in file_groups %}
@@ -992,7 +1018,7 @@
         <h2>Removed Projects</h2>
         {% for project in diffs.removed_projects %}
         <div class="project removed"{% if project.project_metadata is defined %} data-project-kind="{{ project.project_metadata.kind }}"{% endif %}>
-            <h3>{{ project.project }} <small>(<a href="{{ project.project_location }}" target="_blank">{{ project.project_location }}</a>)</small></h3>
+            <h3>{{ project.project }}{{ render_analysis_mode(project.project) }} <small>(<a href="{{ project.project_location }}" target="_blank">{{ project.project_location }}</a>)</small></h3>
             <div style="margin-bottom: 12px;"><strong>Observed outcomes:</strong> {{ render_exit_statuses(project.exit_statuses, project.exit_status_runs) }}</div>
             {% set file_groups = project.diagnostics|groupby('path') %}
             {% for path, diagnostics in file_groups %}
@@ -1013,7 +1039,7 @@
         {% if diffs.modified_projects %}
         {% for project in diffs.modified_projects %}
         <div class="project modified"{% if project.project_metadata is defined %} data-project-kind="{{ project.project_metadata.kind }}"{% endif %}>
-            <h3>{{ project.project }} <small>(<a href="{{ project.project_location }}" target="_blank">{{ project.project_location }}</a>)</small></h3>
+            <h3>{{ project.project }}{{ render_analysis_mode(project.project) }} <small>(<a href="{{ project.project_location }}" target="_blank">{{ project.project_location }}</a>)</small></h3>
             {% if project.diffs.added_files %}
             {% for file_data in project.diffs.added_files %}
             <div class="file added">

--- a/src/ecosystem_analyzer/templates/ecosystem_report.html
+++ b/src/ecosystem_analyzer/templates/ecosystem_report.html
@@ -271,7 +271,7 @@
         <select id="filter-project">
             <option value="all">All {{ projects | length }} projects</option>
             {% for (project, count, is_flaky) in projects %}
-            <option value="{{ project }}">{{ project }} ({{ count }}){% if project in project_strictness %} ({{ 'strict' if project_strictness[project] else 'non-strict' }}){% endif %}{% if is_flaky %} (flaky){% endif %}</option>
+            <option value="{{ project }}">{{ project }} ({{ count }}) ({{ 'strict' if project_strictness[project] else 'non-strict' }}){% if is_flaky %} (flaky){% endif %}</option>
             {% endfor %}
         </select>
 
@@ -323,10 +323,8 @@
                     {% else %}
                         {{ diagnostic.project }}
                     {% endif %}
-                    {% if diagnostic.project in project_strictness %}
-                    {% set strict = project_strictness[diagnostic.project] %}
+                    {% set strict = diagnostic.strict_settings %}
                     <span class="analysis-mode analysis-mode-{{ 'strict' if strict else 'default' }}" title="Strict equality semantics and strict generic narrowing {{ 'enabled' if strict else 'disabled' }}">{{ 'strict' if strict else 'non-strict' }}</span>
-                    {% endif %}
                 </td>
                 <td class="{{ diagnostic.level }}">
                     {{ diagnostic.lint_name }}

--- a/src/ecosystem_analyzer/templates/ecosystem_report.html
+++ b/src/ecosystem_analyzer/templates/ecosystem_report.html
@@ -208,6 +208,25 @@
             margin-left: 6px;
         }
 
+        .analysis-mode {
+            display: inline-block;
+            font-size: 11px;
+            font-weight: 600;
+            padding: 2px 6px;
+            border-radius: 4px;
+            margin-left: 6px;
+        }
+
+        .analysis-mode-strict {
+            color: var(--flare);
+            background: rgba(99, 64, 172, 0.12);
+        }
+
+        .analysis-mode-default {
+            color: var(--rock);
+            background: rgba(120, 135, 110, 0.12);
+        }
+
         .flaky-freq {
             font-weight: 600;
             color: #e65100;
@@ -252,7 +271,7 @@
         <select id="filter-project">
             <option value="all">All {{ projects | length }} projects</option>
             {% for (project, count, is_flaky) in projects %}
-            <option value="{{ project }}">{{ project }} ({{ count }}){% if is_flaky %} (flaky){% endif %}</option>
+            <option value="{{ project }}">{{ project }} ({{ count }}){% if project in project_strictness %} ({{ 'strict' if project_strictness[project] else 'non-strict' }}){% endif %}{% if is_flaky %} (flaky){% endif %}</option>
             {% endfor %}
         </select>
 
@@ -303,6 +322,10 @@
                         <a href="{{ diagnostic.project_location }}">{{ diagnostic.project }}</a>
                     {% else %}
                         {{ diagnostic.project }}
+                    {% endif %}
+                    {% if diagnostic.project in project_strictness %}
+                    {% set strict = project_strictness[diagnostic.project] %}
+                    <span class="analysis-mode analysis-mode-{{ 'strict' if strict else 'default' }}" title="Strict equality semantics and strict generic narrowing {{ 'enabled' if strict else 'disabled' }}">{{ 'strict' if strict else 'non-strict' }}</span>
                     {% endif %}
                 </td>
                 <td class="{{ diagnostic.level }}">

--- a/src/ecosystem_analyzer/ty.py
+++ b/src/ecosystem_analyzer/ty.py
@@ -1,5 +1,6 @@
 """Build and run ty, then aggregate diagnostics and exit evidence."""
 
+import hashlib
 import logging
 import os
 import shlex
@@ -17,6 +18,11 @@ from .installed_project import InstalledProject
 from .schema import Diagnostic, ExitStatus, OutputVariant, RunOutput
 
 logger = logging.getLogger(__name__)
+
+
+def _use_strict_settings(project: InstalledProject) -> bool:
+    """Deterministically select approximately half of project URLs."""
+    return hashlib.sha256(project.location.encode()).digest()[0] % 2 == 0
 
 
 def _normalize_stderr(stderr: str) -> str | None:
@@ -139,6 +145,14 @@ class Ty:
             "--python",
             str(project.venv_path),
         ]
+        strict_settings = _use_strict_settings(project)
+        if strict_settings:
+            standard_flags.extend([
+                "--config",
+                "analysis.strict-equality-semantics=true",
+                "--config",
+                "analysis.strict-generic-narrowing=true",
+            ])
 
         if project.ty_cmd:
             # Use custom ty command from project configuration
@@ -217,6 +231,7 @@ class Ty:
         return RunOutput({
             "project": project.name,
             "project_location": project.location,
+            "strict_settings": strict_settings,
             "ty_commit": self.commit_sha,
             "diagnostics": diagnostics,
             "exit_statuses": [exit_status],
@@ -282,6 +297,7 @@ class Ty:
         result = RunOutput({
             "project": project.name,
             "project_location": project.location,
+            "strict_settings": _use_strict_settings(project),
             "ty_commit": self.commit_sha,
             "diagnostics": stable,
             "flaky_runs": n,

--- a/tests/test_json_roundtrip.py
+++ b/tests/test_json_roundtrip.py
@@ -45,6 +45,7 @@ def _make_output(
     entry: RunOutput = {
         "project": project,
         "project_location": f"https://github.com/example/{project}",
+        "strict_settings": False,
         "ty_commit": "abc123def456",
         "diagnostics": diagnostics,
         "exit_statuses": exit_statuses,

--- a/tests/test_ty.py
+++ b/tests/test_ty.py
@@ -26,6 +26,7 @@ def _output(
     output = RunOutput({
         "project": "proj",
         "project_location": "https://github.com/example/proj",
+        "strict_settings": False,
         "ty_commit": "abc123",
         "diagnostics": diagnostics or [],
         "exit_statuses": [exit_status],


### PR DESCRIPTION
## Summary

- Deterministically enable `analysis.strict-equality-semantics` and `analysis.strict-generic-narrowing` for approximately half of ecosystem projects using a SHA-256 hash of each repository URL.
- Record project strictness for individual and repeated runs, preserve it in diagnostic-diff JSON, and label projects as **strict** or **non-strict** in both HTML report formats.
- The current mypy_primer corpus splits into 78 strict projects and 84 non-strict projects.

## Validation

- `uv run --frozen pytest` — 130 tests passed
- `uv run --frozen ty check`
- `uvx prek run -a`
- End-to-end dummy ty change across all 162 project identities: 78 strict projects changed; all 84 non-strict projects remained unchanged.

## Rollout

- Compared ty revisions must support `analysis.strict-generic-narrowing`.
