### PR TITLE
Handle duplicate diagnostics correctly in ecosystem diffs

### DIFF
--- a/src/ecosystem_analyzer/diff.py
+++ b/src/ecosystem_analyzer/diff.py
@@ -703,25 +703,43 @@ class DiagnosticDiff:
             old_flaky = old_project["flaky_diagnostics"]
             new_flaky = new_project["flaky_diagnostics"]
 
-            # Reconcile stable vs flaky: exclude stable diagnostics at
-            # locations that are flaky on either side.  A stable diagnostic
-            # at a flaky location is unreliable — it just happened to appear
-            # in all N runs of this batch, but is nondeterministic.
-            all_flaky_locs: set[SourceLocationKey] = set()
-            for loc in old_flaky:
-                all_flaky_locs.add((loc["path"], loc["line"], loc["column"]))
-            for loc in new_flaky:
-                all_flaky_locs.add((loc["path"], loc["line"], loc["column"]))
+            # Intermittent duplicates overlap an identical stable diagnostic.
+            # Preserve guaranteed occurrences, but disregard fluctuating
+            # duplicate counts for unchanged or rewritten diagnostics.
+            # Other flaky variants may represent different sampled messages
+            # or lints and require location-level matching.
+            flaky_duplicate_diagnostics: set[str] = set()
+            sampled_flaky_locations: set[SourceLocationKey] = set()
+            for project in (old_project, new_project):
+                stable_diagnostics = {
+                    self._format_diagnostic(diagnostic)
+                    for diagnostic in project["diagnostics"]
+                }
+                for location in project["flaky_diagnostics"]:
+                    for variant in location["variants"]:
+                        diagnostic = variant["diagnostic"]
+                        formatted = self._format_diagnostic(diagnostic)
+                        if formatted in stable_diagnostics:
+                            flaky_duplicate_diagnostics.add(formatted)
+                        else:
+                            sampled_flaky_locations.add((
+                                diagnostic["path"],
+                                diagnostic["line"],
+                                diagnostic["column"],
+                            ))
 
-            old_diagnostics = [
-                d
-                for d in old_project["diagnostics"]
-                if (d["path"], d["line"], d["column"]) not in all_flaky_locs
-            ]
-            new_diagnostics = [
-                d
-                for d in new_project["diagnostics"]
-                if (d["path"], d["line"], d["column"]) not in all_flaky_locs
+            old_diagnostics, new_diagnostics = [
+                [
+                    diagnostic
+                    for diagnostic in project["diagnostics"]
+                    if (
+                        diagnostic["path"],
+                        diagnostic["line"],
+                        diagnostic["column"],
+                    )
+                    not in sampled_flaky_locations
+                ]
+                for project in (old_project, new_project)
             ]
 
             # Compare stable diagnostics
@@ -729,7 +747,9 @@ class DiagnosticDiff:
             new_diagnostics_by_file = self._group_diagnostics_by_file(new_diagnostics)
 
             file_diffs = self._compare_files(
-                old_diagnostics_by_file, new_diagnostics_by_file
+                old_diagnostics_by_file,
+                new_diagnostics_by_file,
+                flaky_duplicate_diagnostics,
             )
 
             # Reconcile flaky vs stable: exclude flaky locations that also
@@ -831,6 +851,7 @@ class DiagnosticDiff:
         self,
         old_files: dict[str, list[Diagnostic]],
         new_files: dict[str, list[Diagnostic]],
+        flaky_duplicate_diagnostics: set[str],
     ) -> FileDiffData:
         """Compare diagnostics across files."""
         result: FileDiffData = {
@@ -885,7 +906,9 @@ class DiagnosticDiff:
             new_diagnostics_by_line = self._group_diagnostics_by_line(new_diagnostics)
 
             line_diffs = self._compare_lines(
-                old_diagnostics_by_line, new_diagnostics_by_line
+                old_diagnostics_by_line,
+                new_diagnostics_by_line,
+                flaky_duplicate_diagnostics,
             )
 
             if (
@@ -922,6 +945,7 @@ class DiagnosticDiff:
         self,
         old_lines: dict[int, list[Diagnostic]],
         new_lines: dict[int, list[Diagnostic]],
+        flaky_duplicate_diagnostics: set[str],
     ) -> LineDiffData:
         """Compare diagnostics across lines."""
         result: LineDiffData = {
@@ -963,66 +987,75 @@ class DiagnosticDiff:
             old_diagnostics = old_lines[line_num]
             new_diagnostics = new_lines[line_num]
 
-            # Convert to formatted strings for comparison
-            old_formatted = {self._format_diagnostic(d) for d in old_diagnostics}
-            new_formatted = {self._format_diagnostic(d) for d in new_diagnostics}
+            old_formatted = Counter(
+                self._format_diagnostic(diagnostic) for diagnostic in old_diagnostics
+            )
+            new_formatted = Counter(
+                self._format_diagnostic(diagnostic) for diagnostic in new_diagnostics
+            )
 
-            # Find differences
             removed = old_formatted - new_formatted
             added = new_formatted - old_formatted
 
+            for diagnostic in (
+                flaky_duplicate_diagnostics
+                & old_formatted.keys()
+                & new_formatted.keys()
+            ):
+                removed.pop(diagnostic, None)
+                added.pop(diagnostic, None)
+
             if removed or added:
-                # Find line-by-line diffs for each diagnostic
                 text_diffs: list[DiagnosticTextDiff] = []
-                changed_old_formatted = set()
-                changed_new_formatted = set()
+                flaky_changed_diagnostics: set[tuple[str, str]] = set()
 
-                removed_diagnostics = [
-                    d for d in old_diagnostics if self._format_diagnostic(d) in removed
-                ]
-                added_diagnostics = [
-                    d for d in new_diagnostics if self._format_diagnostic(d) in added
-                ]
+                while removed and added:
+                    removed_diagnostics = self._diagnostics_with_counts(
+                        old_diagnostics, removed
+                    )
+                    added_diagnostics = self._diagnostics_with_counts(
+                        new_diagnostics, added
+                    )
+                    changed_diagnostics = self._match_changed_diagnostics(
+                        removed_diagnostics, added_diagnostics
+                    )
+                    if not changed_diagnostics:
+                        break
 
-                # Exact string matches are gone. A diagnostic whose text changed
-                # should be reported as one change, not as one removal plus one
-                # addition. Match likely old and new versions before recording
-                # anything left over.
-                for old_diag, new_diag in self._match_changed_diagnostics(
-                    removed_diagnostics, added_diagnostics
-                ):
-                    old_str = self._format_diagnostic(old_diag)
-                    new_str = self._format_diagnostic(new_diag)
-                    diff = self._generate_text_diff(old_str, new_str)
-                    if diff:
+                    for old_diag, new_diag in changed_diagnostics:
+                        old_str = self._format_diagnostic(old_diag)
+                        new_str = self._format_diagnostic(new_diag)
                         text_diffs.append({
                             "old": old_diag,
                             "new": new_diag,
-                            "diff": diff,
+                            "diff": self._generate_text_diff(old_str, new_str),
                         })
-                        changed_old_formatted.add(old_str)
-                        changed_new_formatted.add(new_str)
+                        if (
+                            old_str in flaky_duplicate_diagnostics
+                            or new_str in flaky_duplicate_diagnostics
+                        ):
+                            flaky_changed_diagnostics.add((old_str, new_str))
 
-                # Filter out diagnostics that are part of changes
-                removed_diagnostics = [
-                    d
-                    for d in old_diagnostics
-                    if self._format_diagnostic(d) in removed
-                    and self._format_diagnostic(d) not in changed_old_formatted
-                ]
-                added_diagnostics = [
-                    d
-                    for d in new_diagnostics
-                    if self._format_diagnostic(d) in added
-                    and self._format_diagnostic(d) not in changed_new_formatted
-                ]
-                # Sort removed and added diagnostics
+                        occurrences = min(removed[old_str], added[new_str])
+                        removed[old_str] -= occurrences
+                        added[new_str] -= occurrences
+                        if removed[old_str] == 0:
+                            del removed[old_str]
+                        if added[new_str] == 0:
+                            del added[new_str]
+
+                # Finish matching distinct rewrites before discarding surplus
+                # copies whose multiplicity fluctuated in either revision.
+                for old_str, new_str in flaky_changed_diagnostics:
+                    removed.pop(old_str, None)
+                    added.pop(new_str, None)
+
                 removed_diagnostics = sorted(
-                    removed_diagnostics,
+                    self._diagnostics_with_counts(old_diagnostics, removed),
                     key=lambda d: (d["column"], d["message"]),
                 )
                 added_diagnostics = sorted(
-                    added_diagnostics,
+                    self._diagnostics_with_counts(new_diagnostics, added),
                     key=lambda d: (d["column"], d["message"]),
                 )
 
@@ -1033,6 +1066,21 @@ class DiagnosticDiff:
                     "text_diffs": text_diffs,
                 })
 
+        return result
+
+    def _diagnostics_with_counts(
+        self,
+        diagnostics: list[Diagnostic],
+        counts: Counter[str],
+    ) -> list[Diagnostic]:
+        """Return each diagnostic at most as often as its remaining occurrence count."""
+        remaining = counts.copy()
+        result = []
+        for diagnostic in diagnostics:
+            formatted = self._format_diagnostic(diagnostic)
+            if remaining[formatted]:
+                result.append(diagnostic)
+                remaining[formatted] -= 1
         return result
 
     def _match_changed_diagnostics(

--- a/src/ecosystem_analyzer/flaky.py
+++ b/src/ecosystem_analyzer/flaky.py
@@ -33,8 +33,9 @@ def classify_diagnostics(
 ) -> tuple[list[Diagnostic], list[FlakyLocation]]:
     """Classify diagnostics from multiple runs as stable or flaky.
 
-    A diagnostic is "stable" if it appears in ALL runs (by exact key match).
-    All other diagnostics are "flaky" and grouped by (path, line).
+    A diagnostic occurrence is "stable" if it appears in ALL runs.
+    Repeated stable diagnostics are preserved, while intermittent duplicate
+    occurrences are "flaky" and grouped by (path, line).
 
     Each flaky variant records how many runs it appeared in.
 
@@ -43,27 +44,26 @@ def classify_diagnostics(
     n = len(all_runs)
     assert n >= 2, "Need at least 2 runs to detect flakiness"
 
-    # Count how many runs each diagnostic key appears in
-    key_counts: Counter[DiagnosticKey] = Counter()
+    # Include occurrence indexes so duplicate diagnostics count independently.
+    occurrence_counts: Counter[tuple[DiagnosticKey, int]] = Counter()
     # Keep one representative Diagnostic for each key
     key_to_diag: dict[DiagnosticKey, Diagnostic] = {}
 
     for run_diagnostics in all_runs:
-        # Deduplicate within a single run — a key counts once per run
-        seen_in_run: set[DiagnosticKey] = set()
+        occurrences_in_run: Counter[DiagnosticKey] = Counter()
         for diag in run_diagnostics:
             key = _diagnostic_key(diag)
-            if key not in seen_in_run:
-                seen_in_run.add(key)
-                key_counts[key] += 1
-                if key not in key_to_diag:
-                    key_to_diag[key] = diag
+            occurrence = occurrences_in_run[key]
+            occurrences_in_run[key] += 1
+            occurrence_counts[key, occurrence] += 1
+            if key not in key_to_diag:
+                key_to_diag[key] = diag
 
     # Partition into stable and flaky
     stable: list[Diagnostic] = []
     flaky_by_location: dict[SourceLocationKey, list[FlakyVariant]] = {}
 
-    for key, count in key_counts.items():
+    for (key, _occurrence), count in occurrence_counts.items():
         diag = key_to_diag[key]
         if count == n:
             stable.append(diag)

--- a/tests/test_flaky.py
+++ b/tests/test_flaky.py
@@ -132,8 +132,8 @@ class TestClassifyDiagnostics:
         assert flaky[0]["column"] == 1
         assert flaky[1]["column"] == 5
 
-    def test_deduplication_within_run(self) -> None:
-        """Duplicate diagnostics within a single run don't inflate counts."""
+    def test_duplicate_occurrences_are_classified_independently(self) -> None:
+        """Extra copies present in only some runs are flaky occurrences."""
         d = _diag("a.py", 1, 1, "msg")
 
         stable, flaky = classify_diagnostics([
@@ -141,8 +141,37 @@ class TestClassifyDiagnostics:
             [d],
         ])
 
-        assert len(stable) == 1
-        assert len(flaky) == 0
+        assert stable == [d]
+        assert len(flaky) == 1
+        assert [variant["count"] for variant in flaky[0]["variants"]] == [1, 1]
+        assert all(variant["diagnostic"] == d for variant in flaky[0]["variants"])
+
+    def test_duplicate_diagnostics_present_in_every_run_are_preserved(self) -> None:
+        """Stable diagnostics retain the multiplicity shared by every run."""
+        diagnostic = _diag("a.py", 1, 1, "msg")
+
+        stable, flaky = classify_diagnostics([
+            [diagnostic, diagnostic],
+            [diagnostic, diagnostic],
+            [diagnostic, diagnostic],
+        ])
+
+        assert stable == [diagnostic, diagnostic]
+        assert flaky == []
+
+    def test_duplicate_occurrences_preserve_individual_frequencies(self) -> None:
+        """Each intermittent duplicate records how many runs contained that copy."""
+        diagnostic = _diag("a.py", 1, 1, "msg")
+
+        stable, flaky = classify_diagnostics([
+            [diagnostic, diagnostic, diagnostic],
+            [diagnostic, diagnostic],
+            [diagnostic, diagnostic, diagnostic, diagnostic],
+        ])
+
+        assert stable == [diagnostic, diagnostic]
+        assert len(flaky) == 1
+        assert [variant["count"] for variant in flaky[0]["variants"]] == [2, 1]
 
     def test_two_runs_minimum(self) -> None:
         """Two runs is the minimum for flaky detection."""

--- a/tests/test_json_roundtrip.py
+++ b/tests/test_json_roundtrip.py
@@ -2,7 +2,10 @@ import json
 import tempfile
 from pathlib import Path
 
+import pytest
+
 from ecosystem_analyzer.diff import DiagnosticDiff
+from ecosystem_analyzer.flaky import classify_diagnostics
 from ecosystem_analyzer.schema import (
     Diagnostic,
     DiagnosticLevel,
@@ -1476,6 +1479,370 @@ info: Args: /tmp/new_commit/ty check ."""
             (item["old"]["message"], item["new"]["message"])
             for item in modified_line["text_diffs"]
         } == {(old_int, new_int), (old_str, new_str)}
+
+    @pytest.mark.parametrize("flaky_runs", [0, 10], ids=["single-run", "repeated-run"])
+    @pytest.mark.parametrize(
+        ("old_messages", "new_messages", "changed", "added", "removed"),
+        [
+            pytest.param(
+                ["Expected `Series`", "Expected `Series`"],
+                ["Expected `Series`", "Expected `pandas.Series`"],
+                1,
+                0,
+                0,
+                id="duplicate-becomes-distinguishable",
+            ),
+            pytest.param(
+                ["Expected `Series`", "Expected `pandas.Series`"],
+                ["Expected `Series`", "Expected `Series`"],
+                1,
+                0,
+                0,
+                id="distinct-diagnostics-become-duplicates",
+            ),
+            pytest.param(
+                ["Expected `Series`"],
+                ["Expected `Series`", "Expected `Series`"],
+                0,
+                1,
+                0,
+                id="duplicate-added",
+            ),
+            pytest.param(
+                ["Expected `Series`", "Expected `Series`"],
+                ["Expected `Series`"],
+                0,
+                0,
+                1,
+                id="duplicate-removed",
+            ),
+            pytest.param(
+                ["Expected `Series`", "Expected `Series`"],
+                ["Expected `pandas.Series`", "Expected `pyspark.Series`"],
+                2,
+                0,
+                0,
+                id="all-duplicates-become-distinguishable",
+            ),
+            pytest.param(
+                ["Expected `Series`", "Expected `Series`"],
+                [
+                    "Expected `pandas.Series`",
+                    "Expected `pandas.Series`",
+                    "Expected `pandas.Series`",
+                ],
+                1,
+                1,
+                0,
+                id="rewritten-duplicates-include-addition",
+            ),
+            pytest.param(
+                ["Expected `Series`", "Expected `Series`", "Expected `Series`"],
+                ["Expected `pandas.Series`", "Expected `pandas.Series`"],
+                1,
+                0,
+                1,
+                id="rewritten-duplicates-include-removal",
+            ),
+        ],
+    )
+    def test_duplicate_diagnostic_occurrences_are_preserved(
+        self,
+        old_messages: list[str],
+        new_messages: list[str],
+        changed: int,
+        added: int,
+        removed: int,
+        flaky_runs: int,
+    ) -> None:
+        def make_diag(message: str) -> Diagnostic:
+            return {
+                "level": "error",
+                "lint_name": "invalid-argument-type",
+                "path": "a.py",
+                "line": 1,
+                "column": 1,
+                "message": message,
+            }
+
+        old_diagnostics = [make_diag(message) for message in old_messages]
+        new_diagnostics = [make_diag(message) for message in new_messages]
+        if flaky_runs:
+            old_diagnostics, _ = classify_diagnostics([old_diagnostics] * flaky_runs)
+            new_diagnostics, _ = classify_diagnostics([new_diagnostics] * flaky_runs)
+
+        diff = _make_diff(
+            [_make_output("project", old_diagnostics, flaky_runs=flaky_runs)],
+            [_make_output("project", new_diagnostics, flaky_runs=flaky_runs)],
+        )
+        statistics = diff._calculate_statistics()
+
+        assert statistics["total_changed"] == changed
+        assert statistics["total_added"] == added
+        assert statistics["total_removed"] == removed
+
+    @pytest.mark.parametrize(
+        "rewrite_message", [False, True], ids=["unchanged", "rewritten"]
+    )
+    @pytest.mark.parametrize(
+        ("old_occurrences", "new_occurrences"),
+        [
+            pytest.param([2, 3], [1, 2], id="both-sides-flaky-removal"),
+            pytest.param([1, 2], [2, 3], id="both-sides-flaky-addition"),
+            pytest.param([2, 2], [1, 2], id="new-side-flaky"),
+            pytest.param([1, 2], [2, 2], id="old-side-flaky"),
+        ],
+    )
+    def test_flaky_duplicate_occurrences_do_not_create_spurious_changes(
+        self,
+        old_occurrences: list[int],
+        new_occurrences: list[int],
+        rewrite_message: bool,
+    ) -> None:
+        def output(occurrences: list[int], message: str) -> RunOutput:
+            diagnostic: Diagnostic = {
+                "level": "error",
+                "lint_name": "invalid-argument-type",
+                "path": "a.py",
+                "line": 1,
+                "column": 1,
+                "message": message,
+            }
+            runs = [[diagnostic] * count for count in occurrences]
+            stable, flaky = classify_diagnostics(runs)
+            return _make_output("project", stable, flaky, flaky_runs=len(runs))
+
+        old_output = output(old_occurrences, "Expected `Series`")
+        new_output = output(
+            new_occurrences,
+            "Expected `pandas.Series`" if rewrite_message else "Expected `Series`",
+        )
+        diff = _make_diff([old_output], [new_output])
+        statistics = diff._calculate_statistics()
+
+        assert old_output["flaky_diagnostics"] or new_output["flaky_diagnostics"]
+        assert statistics["total_changed"] == int(rewrite_message)
+        assert statistics["total_added"] == 0
+        assert statistics["total_removed"] == 0
+
+    @pytest.mark.parametrize(
+        ("old_messages", "new_messages", "changed", "added", "removed"),
+        [
+            pytest.param(
+                [[], []],
+                [["new diagnostic", "new diagnostic"], ["new diagnostic"]],
+                0,
+                1,
+                0,
+                id="added",
+            ),
+            pytest.param(
+                [["old diagnostic", "old diagnostic"], ["old diagnostic"]],
+                [[], []],
+                0,
+                0,
+                1,
+                id="removed",
+            ),
+            pytest.param(
+                [["old diagnostic", "old diagnostic"], ["old diagnostic"]],
+                [["new diagnostic"], ["new diagnostic"]],
+                1,
+                0,
+                0,
+                id="changed-old-flaky",
+            ),
+            pytest.param(
+                [["old diagnostic"], ["old diagnostic"]],
+                [["new diagnostic", "new diagnostic"], ["new diagnostic"]],
+                1,
+                0,
+                0,
+                id="changed-new-flaky",
+            ),
+            pytest.param(
+                [["old diagnostic", "old diagnostic"], ["old diagnostic"]],
+                [["new diagnostic", "new diagnostic"], ["new diagnostic"]],
+                1,
+                0,
+                0,
+                id="changed-both-flaky",
+            ),
+        ],
+    )
+    def test_stable_occurrences_survive_their_own_flaky_duplicate(
+        self,
+        old_messages: list[list[str]],
+        new_messages: list[list[str]],
+        changed: int,
+        added: int,
+        removed: int,
+    ) -> None:
+        def output(messages: list[list[str]]) -> RunOutput:
+            runs: list[list[Diagnostic]] = [
+                [
+                    {
+                        "level": "error",
+                        "lint_name": "invalid-argument-type",
+                        "path": "a.py",
+                        "line": 1,
+                        "column": 1,
+                        "message": message,
+                    }
+                    for message in run
+                ]
+                for run in messages
+            ]
+            stable, flaky = classify_diagnostics(runs)
+            return _make_output("project", stable, flaky, flaky_runs=len(runs))
+
+        diff = _make_diff([output(old_messages)], [output(new_messages)])
+        statistics = diff._calculate_statistics()
+
+        assert statistics["total_changed"] == changed
+        assert statistics["total_added"] == added
+        assert statistics["total_removed"] == removed
+
+        markdown = diff.render_statistics_markdown()
+        html = _render_html(diff)
+        for messages in (*old_messages, *new_messages):
+            for message in messages:
+                assert message in markdown
+                assert message in html
+
+    @pytest.mark.parametrize(
+        "stable_lint_name",
+        [
+            pytest.param("flaky-lint", id="same-lint"),
+            pytest.param("stable-lint", id="different-lint"),
+        ],
+    )
+    @pytest.mark.parametrize(
+        ("old_message", "new_message", "changed", "added", "removed"),
+        [
+            pytest.param(None, "new stable diagnostic", 0, 1, 0, id="added"),
+            pytest.param("old stable diagnostic", None, 0, 0, 1, id="removed"),
+            pytest.param(
+                "old stable diagnostic",
+                "new stable diagnostic",
+                1,
+                0,
+                0,
+                id="changed",
+            ),
+        ],
+    )
+    def test_stable_diagnostics_survive_unrelated_flaky_duplicate(
+        self,
+        old_message: str | None,
+        new_message: str | None,
+        changed: int,
+        added: int,
+        removed: int,
+        stable_lint_name: str,
+    ) -> None:
+        duplicate: Diagnostic = {
+            "level": "error",
+            "lint_name": "flaky-lint",
+            "path": "a.py",
+            "line": 1,
+            "column": 1,
+            "message": "intermittently duplicated diagnostic",
+        }
+
+        def output(message: str | None) -> RunOutput:
+            other_diagnostics: list[Diagnostic] = []
+            if message is not None:
+                other_diagnostics.append({
+                    **duplicate,
+                    "lint_name": stable_lint_name,
+                    "message": message,
+                })
+
+            runs = [
+                [duplicate, duplicate, *other_diagnostics],
+                [duplicate, *other_diagnostics],
+            ]
+            stable, flaky = classify_diagnostics(runs)
+            return _make_output("project", stable, flaky, flaky_runs=len(runs))
+
+        diff = _make_diff([output(old_message)], [output(new_message)])
+        statistics = diff._calculate_statistics()
+
+        assert statistics["total_changed"] == changed
+        assert statistics["total_added"] == added
+        assert statistics["total_removed"] == removed
+
+        markdown = diff.render_statistics_markdown()
+        html = _render_html(diff)
+        for message in (old_message, new_message):
+            if message is not None:
+                assert message in markdown
+                assert message in html
+
+    @pytest.mark.parametrize(
+        "vary_lint_names",
+        [
+            pytest.param(False, id="same-lint"),
+            pytest.param(True, id="different-lints"),
+        ],
+    )
+    @pytest.mark.parametrize(
+        ("old_messages", "new_messages"),
+        [
+            pytest.param(
+                ["Expected `int`"] * 5 + ["Expected `str`"] * 5,
+                ["Expected `bytes`"] * 10,
+                id="apparently-added",
+            ),
+            pytest.param(
+                ["Expected `bytes`"] * 10,
+                ["Expected `int`"] * 5 + ["Expected `str`"] * 5,
+                id="apparently-removed",
+            ),
+        ],
+    )
+    def test_independently_sampled_flaky_variants_are_excluded_from_statistics(
+        self,
+        old_messages: list[str],
+        new_messages: list[str],
+        vary_lint_names: bool,
+    ) -> None:
+        lint_names = {
+            "Expected `int`": "invalid-argument-type",
+            "Expected `str`": "invalid-return-type",
+            "Expected `bytes`": "invalid-assignment",
+        }
+
+        def output(messages: list[str]) -> RunOutput:
+            runs: list[list[Diagnostic]] = [
+                [
+                    {
+                        "level": "error",
+                        "lint_name": (
+                            lint_names[message]
+                            if vary_lint_names
+                            else "invalid-argument-type"
+                        ),
+                        "path": "a.py",
+                        "line": 1,
+                        "column": 1,
+                        "message": message,
+                    }
+                ]
+                for message in messages
+            ]
+            stable, flaky = classify_diagnostics(runs)
+            return _make_output("project", stable, flaky, flaky_runs=len(runs))
+
+        diff = _make_diff([output(old_messages)], [output(new_messages)])
+        statistics = diff._calculate_statistics()
+
+        assert statistics["total_changed"] == 0
+        assert statistics["total_added"] == 0
+        assert statistics["total_removed"] == 0
+        assert "Expected `bytes`" not in diff.render_statistics_markdown()
+        assert "Expected `bytes`" not in _render_html(diff)
 
     def test_competing_rewritten_diagnostics_are_matched_globally(self) -> None:
         """Competing rewrites are paired by the best assignment for the whole group."""


### PR DESCRIPTION
## Summary

Ecosystem diffs currently compare diagnostics on the same source line as sets of formatted messages. When ty emits the same diagnostic more than once, that discards occurrence counts: rewriting one copy can look like a newly added or removed diagnostic, and genuinely adding or removing a duplicate can disappear entirely. Repeated-run flaky classification also deduplicates diagnostics, so the same problems reappear for projects run with `--flaky-runs`.

This PR preserves diagnostic multiplicity throughout classification and comparison, while keeping nondeterministic duplicate counts out of stable ecosystem results.

## Examples

Let `A` and `B` be different diagnostic messages for the same lint at the same source location.

| Baseline diagnostics | Candidate diagnostics | Current result | Result with this PR |
| --- | --- | --- | --- |
| `A, A` | `A, B` | Incorrectly reports `B` as an addition | Reports one diagnostic rewritten from `A` to `B` |
| `A, B` | `A, A` | Incorrectly reports `B` as a removal | Reports one diagnostic rewritten from `B` to `A` |
| `A` | `A, A` | Reports no change | Reports one genuinely added duplicate |
| `A, A` | `A` | Reports no change | Reports one genuinely removed duplicate |

Repeated runs also need to distinguish guaranteed occurrences from intermittent duplicates:

```text
Baseline runs:  [A, A], [A, A, A]
Candidate runs: [A],    [A, A]
```

Both revisions exhibit fluctuating duplicate counts, so the diff should report **no stable additions or removals**.

If the diagnostic itself changes while its duplicate count fluctuates:

```text
Baseline runs:  [A, A], [A, A, A]
Candidate runs: [B],    [B, B]
```

The diff should report **one changed diagnostic**, without inventing an additional removal.

An intermittent duplicate must not hide another genuine diagnostic at the same source location:

```text
Baseline runs:  [A, A],    [A]
Candidate runs: [A, A, B], [A, B]
```

Here the stable `B` diagnostic must still be reported as **one real addition**.

## Implementation

- Compare formatted diagnostics with occurrence-aware `Counter` values instead of sets, and repeatedly match rewritten diagnostics until all distinct changes are accounted for.
- Classify repeated-run diagnostics by both diagnostic identity and occurrence index, preserving guaranteed duplicates and recording intermittent copies as flaky variants.
- Reconcile fluctuating duplicate counts for both unchanged diagnostics and matched rewrites while preserving genuine stable additions, removals, and changes.
- Keep existing source-location suppression for independently sampled flaky message or lint variants, without suppressing unrelated stable diagnostics merely because an intermittent duplicate shares their location.