### PR TITLE
Update mypy-primer to fix AutoSplit dependency installation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "A tool for analyzing Python projects with ty"
 dependencies = [
     "gitpython==3.1.57",
-    "mypy-primer @ git+https://github.com/hauntsaninja/mypy_primer@6d6eebd8d37c9b8931381e79aa99808d9378c988",
+    "mypy-primer @ git+https://github.com/hauntsaninja/mypy_primer@db37f8a384c45c02fc52544fd819f979d66e174a",
     "click==8.4.2",
     "jinja2==3.1.6",
     "typing-extensions>=4.16.0",

--- a/uv.lock
+++ b/uv.lock
@@ -46,7 +46,7 @@ requires-dist = [
     { name = "click", specifier = "==8.4.2" },
     { name = "gitpython", specifier = "==3.1.57" },
     { name = "jinja2", specifier = "==3.1.6" },
-    { name = "mypy-primer", git = "https://github.com/hauntsaninja/mypy_primer?rev=6d6eebd8d37c9b8931381e79aa99808d9378c988" },
+    { name = "mypy-primer", git = "https://github.com/hauntsaninja/mypy_primer?rev=db37f8a384c45c02fc52544fd819f979d66e174a" },
     { name = "typing-extensions", specifier = ">=4.16.0" },
 ]
 
@@ -156,7 +156,7 @@ wheels = [
 [[package]]
 name = "mypy-primer"
 version = "0.1.0"
-source = { git = "https://github.com/hauntsaninja/mypy_primer?rev=6d6eebd8d37c9b8931381e79aa99808d9378c988#6d6eebd8d37c9b8931381e79aa99808d9378c988" }
+source = { git = "https://github.com/hauntsaninja/mypy_primer?rev=db37f8a384c45c02fc52544fd819f979d66e174a#db37f8a384c45c02fc52544fd819f979d66e174a" }
 
 [[package]]
 name = "packaging"


### PR DESCRIPTION
Update the pinned mypy-primer revision to include https://github.com/hauntsaninja/mypy_primer/pull/258, which sets AutoSplit's minimum Python version to 3.14.

This prevents ecosystem analysis from attempting to install AutoSplit's `numpy>=2.5.2` override into a Python 3.11 environment.
