### PR TITLE
Update mypy-primer pin to latest master

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "A tool for analyzing Python projects with ty"
 dependencies = [
     "gitpython==3.1.57",
-    "mypy-primer @ git+https://github.com/hauntsaninja/mypy_primer@db37f8a384c45c02fc52544fd819f979d66e174a",
+    "mypy-primer @ git+https://github.com/hauntsaninja/mypy_primer@3058720299b812c393ad926bcca96eede20fa683",
     "click==8.4.2",
     "jinja2==3.1.6",
     "typing-extensions>=4.16.0",

--- a/uv.lock
+++ b/uv.lock
@@ -52,7 +52,7 @@ requires-dist = [
     { name = "click", specifier = "==8.4.2" },
     { name = "gitpython", specifier = "==3.1.57" },
     { name = "jinja2", specifier = "==3.1.6" },
-    { name = "mypy-primer", git = "https://github.com/hauntsaninja/mypy_primer?rev=db37f8a384c45c02fc52544fd819f979d66e174a" },
+    { name = "mypy-primer", git = "https://github.com/hauntsaninja/mypy_primer?rev=3058720299b812c393ad926bcca96eede20fa683" },
     { name = "typing-extensions", specifier = ">=4.16.0" },
 ]
 
@@ -162,7 +162,7 @@ wheels = [
 [[package]]
 name = "mypy-primer"
 version = "0.1.0"
-source = { git = "https://github.com/hauntsaninja/mypy_primer?rev=db37f8a384c45c02fc52544fd819f979d66e174a#db37f8a384c45c02fc52544fd819f979d66e174a" }
+source = { git = "https://github.com/hauntsaninja/mypy_primer?rev=3058720299b812c393ad926bcca96eede20fa683#3058720299b812c393ad926bcca96eede20fa683" }
 
 [[package]]
 name = "packaging"


### PR DESCRIPTION
Update the pinned mypy-primer revision from db37f8a384c45c02fc52544fd819f979d66e174a to 3058720299b812c393ad926bcca96eede20fa683, picking up the latest upstream master and its missing ecosystem-project dependency fixes.