### PR TITLE
[ty] Sync script dependencies before timing checks

### DIFF
--- a/src/ecosystem_analyzer/config.py
+++ b/src/ecosystem_analyzer/config.py
@@ -4,5 +4,10 @@
 MINIMUM_PYTHON_VERSION = (3, 11)
 
 # Prevent source-distribution builds during script preparation and ty runs.
-# Binary exclusions otherwise override no-build. Editable build hooks remain possible.
-UV_NO_BUILD_ENV = {"UV_NO_BUILD": "1", "UV_NO_BINARY": "0"}
+# Binary exclusions otherwise override no-build.
+# uv 0.12.5 ignores no-editable for scripts without lockfiles.
+UV_NO_BUILD_ENV = {
+    "UV_NO_BUILD": "1",
+    "UV_NO_BINARY": "0",
+    "UV_NO_EDITABLE": "1",
+}

--- a/src/ecosystem_analyzer/config.py
+++ b/src/ecosystem_analyzer/config.py
@@ -5,9 +5,7 @@ MINIMUM_PYTHON_VERSION = (3, 11)
 
 # Prevent source-distribution builds during script preparation and ty runs.
 # Binary exclusions otherwise override no-build.
-# uv 0.12.5 ignores no-editable for scripts without lockfiles.
 UV_NO_BUILD_ENV = {
     "UV_NO_BUILD": "1",
     "UV_NO_BINARY": "0",
-    "UV_NO_EDITABLE": "1",
 }

--- a/src/ecosystem_analyzer/config.py
+++ b/src/ecosystem_analyzer/config.py
@@ -2,3 +2,7 @@
 
 # Projects may require a newer Python version than this baseline.
 MINIMUM_PYTHON_VERSION = (3, 11)
+
+# Prevent source-distribution builds during script preparation and ty runs.
+# Binary exclusions otherwise override no-build. Editable build hooks remain possible.
+UV_NO_BUILD_ENV = {"UV_NO_BUILD": "1", "UV_NO_BINARY": "0"}

--- a/src/ecosystem_analyzer/installed_project.py
+++ b/src/ecosystem_analyzer/installed_project.py
@@ -274,7 +274,8 @@ class InstalledProject:
     def _install_script_dependencies(self) -> None:
         # Prepare script environments before timing either ty revision, so the baseline
         # does not pay installation costs that subsequent runs avoid through cache reuse.
-        # This marker search is intentionally approximate; ty still validates the metadata.
+        # This marker search is intentionally approximate; ty still applies exclusions
+        # and validates the metadata.
         try:
             scripts = self._repo.git.grep(
                 "--files-with-matches",
@@ -282,8 +283,7 @@ class InstalledProject:
                 "--extended-regexp",
                 "^# /// script[[:space:]]*$",
                 "--",
-                "*.py",
-                "*.pyi",
+                *self.paths,
             )
         except GitCommandError as error:
             if error.status == 1:
@@ -291,7 +291,7 @@ class InstalledProject:
             raise
 
         for script in scripts.split("\0"):
-            if not script:
+            if Path(script).suffix not in {".py", ".pyi"}:
                 continue
             path = self.root_directory / script
             logger.info(f"Preparing script environment: {path}")

--- a/src/ecosystem_analyzer/installed_project.py
+++ b/src/ecosystem_analyzer/installed_project.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from git import GitCommandError, GitError, Repo
 from mypy_primer.model import Project
 
-from .config import MINIMUM_PYTHON_VERSION
+from .config import MINIMUM_PYTHON_VERSION, UV_NO_BUILD_ENV
 
 logger = logging.getLogger(__name__)
 
@@ -290,6 +290,7 @@ class InstalledProject:
                 return
             raise
 
+        env = {**os.environ, **UV_NO_BUILD_ENV}
         for script in scripts.split("\0"):
             if Path(script).suffix not in {".py", ".pyi"}:
                 continue
@@ -311,6 +312,7 @@ class InstalledProject:
                     capture_output=True,
                     text=True,
                     timeout=180,
+                    env=env,
                 )
             except subprocess.TimeoutExpired:
                 logger.warning(f"Timed out preparing script environment: {path}")

--- a/src/ecosystem_analyzer/installed_project.py
+++ b/src/ecosystem_analyzer/installed_project.py
@@ -8,7 +8,7 @@ import subprocess
 import tempfile
 from pathlib import Path
 
-from git import GitError, Repo
+from git import GitCommandError, GitError, Repo
 from mypy_primer.model import Project
 
 from .config import MINIMUM_PYTHON_VERSION
@@ -266,4 +266,59 @@ class InstalledProject:
                 capture_output=False,
             )
         if not self._project.install_cmd and not self._project.deps:
-            logger.info("No dependencies to install")
+            logger.info("No project dependencies to install")
+
+        if os.environ.get("TY_UV") in {"scripts", "1", "true"}:
+            self._install_script_dependencies()
+
+    def _install_script_dependencies(self) -> None:
+        # Prepare script environments before timing either ty revision, so the baseline
+        # does not pay installation costs that subsequent runs avoid through cache reuse.
+        # This marker search is intentionally approximate; ty still validates the metadata.
+        try:
+            scripts = self._repo.git.grep(
+                "--files-with-matches",
+                "--null",
+                "--extended-regexp",
+                "^# /// script[[:space:]]*$",
+                "--",
+                "*.py",
+                "*.pyi",
+            )
+        except GitCommandError as error:
+            if error.status == 1:
+                return
+            raise
+
+        for script in scripts.split("\0"):
+            if not script:
+                continue
+            path = self.root_directory / script
+            logger.info(f"Preparing script environment: {path}")
+            try:
+                result = subprocess.run(
+                    [
+                        os.environ.get("UV", "uv"),
+                        "sync",
+                        "--quiet",
+                        "--script",
+                        str(path),
+                        "--python",
+                        str(self.venv_path),
+                    ],
+                    cwd=path.parent,
+                    check=False,
+                    capture_output=True,
+                    text=True,
+                    timeout=180,
+                )
+            except subprocess.TimeoutExpired:
+                logger.warning(f"Timed out preparing script environment: {path}")
+                continue
+
+            if result.returncode != 0:
+                # Invalid metadata and unsatisfiable dependencies are reported by ty;
+                # a preparation failure must not prevent the project from being checked.
+                logger.warning(
+                    f"Failed to prepare script environment for {path}: {result.stderr.strip()}"
+                )

--- a/src/ecosystem_analyzer/installed_project.py
+++ b/src/ecosystem_analyzer/installed_project.py
@@ -272,8 +272,9 @@ class InstalledProject:
             self._install_script_dependencies()
 
     def _install_script_dependencies(self) -> None:
-        # Prepare script environments before timing either ty revision, so the baseline
-        # does not pay installation costs that subsequent runs avoid through cache reuse.
+        # Match ty's metadata sync before timing either revision, so the baseline
+        # does not pay resolution and installation costs that subsequent runs avoid
+        # through cache reuse.
         # This marker search is intentionally approximate; ty still applies exclusions
         # and validates the metadata.
         try:
@@ -300,7 +301,9 @@ class InstalledProject:
                 result = subprocess.run(
                     [
                         os.environ.get("UV", "uv"),
-                        "sync",
+                        "workspace",
+                        "metadata",
+                        "--sync",
                         "--quiet",
                         "--script",
                         str(path),

--- a/src/ecosystem_analyzer/ty.py
+++ b/src/ecosystem_analyzer/ty.py
@@ -12,6 +12,7 @@ from pathlib import Path
 
 from git import Commit, Repo
 
+from .config import UV_NO_BUILD_ENV
 from .diagnostic import DiagnosticsParser, index_panic_messages
 from .flaky import classify_diagnostics
 from .installed_project import InstalledProject
@@ -177,6 +178,7 @@ class Ty:
                 *project.paths,
             ]
         logger.debug(f"Executing: {' '.join(cmd)}")
+        env = {**os.environ, **UV_NO_BUILD_ENV}
         start_time = time.time()
         try:
             result = subprocess.run(
@@ -186,6 +188,7 @@ class Ty:
                 capture_output=True,
                 text=True,
                 timeout=30 if self.profile in {"profiling", "release"} else 180,
+                env=env,
             )
 
             execution_time = time.time() - start_time


### PR DESCRIPTION
## Summary

We now run the ecosystem analyzer with an opt-in to ty's experimental script's support. This means, ty now calls uv to sync each script's dependencies. 

What I didn't consider when enabling this opt-in is that the baseline run pays for downloading the script's dependencies. This skews the timing comparison because the "PR" run benefits from an initialized uv cache. 

This PR adds a somewhat naive script discovery to ecosystem-analyzer and calls `uv sync` for each likely-to-be script. This pre-warm the uv cache, so that the timing report compares two ty runs with a warm uv cache (we aren't interested in measuring uv's cold install speed).

This PR also hardens our CI pipeline by setting `UV_NO_BUILD` and `UV_NO_BINARY`. This makes a few scripts fail to install their dependencies, but that's preferred over running install scripts of dependencies that are out of our control (unlike mypy primer where dependencies are allowlisted) 

## Test plan

I ran ecosystem analyzer locally