### PR TITLE
Enforce a 30-day dependency cooldown in uv

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,11 +101,18 @@ exclude = ["plots"]
 dev = ["pytest>=8.4.1", "ty==0.0.74"]
 
 [tool.uv]
+# Work around Renovate not enforcing its configured cooldown for lockfile-maintenance PRs:
+# https://docs.renovatebot.com/presets-security/#securityminimumreleaseagepypi
+# Enforce the same 30-day cooldown specified in our shared Renovate config:
+# https://github.com/astral-sh/renovate-config/blob/0146d963693a5335c975355d8383fe6933f5dc95/preset.json5#L46
+exclude-newer = "P30D"
+# Exempt the Astral tools pinned in this project.
+exclude-newer-package = { ty = false, uv-build = false }
 no-build = true
 # The project is installed locally, and mypy-primer is pinned to Git.
 no-binary-package = ["ecosystem-analyzer", "mypy-primer"]
 # Pin the isolated build environment for source-build exceptions.
 build-constraint-dependencies = [
-    "setuptools==84.0.0",
+    "setuptools==83.0.0",
     "uv-build==0.12.3",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -2,9 +2,17 @@ version = 1
 revision = 3
 requires-python = ">=3.13"
 
+[options]
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer-span = "P30D"
+
+[options.exclude-newer-package]
+uv-build = false
+ty = false
+
 [manifest]
 build-constraints = [
-    { name = "setuptools", specifier = "==84.0.0" },
+    { name = "setuptools", specifier = "==83.0.0" },
     { name = "uv-build", specifier = "==0.12.3" },
 ]
 
@@ -166,11 +174,11 @@ source = { git = "https://github.com/hauntsaninja/mypy_primer?rev=3058720299b812
 
 [[package]]
 name = "packaging"
-version = "26.3"
+version = "26.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/7d/fa/3944b40b07da9ce895c0e6303a5ab7d53da063554f534556b134a54d6093/packaging-26.3.tar.gz", hash = "sha256:94edc256424af38762eb31306eed28beb9f0efc50a8837492c9d6fd6004aed79", size = 313412, upload-time = "2026-08-04T18:15:28.737Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/63/34/ba1c580383c9eada3711951fef0795c80b829a078d72188184bcab9dd527/packaging-26.3-py3-none-any.whl", hash = "sha256:d7193f7c8e4e93f444fde0262bf90af30e16fa0ad0ad44cb553c87339b23cd1c", size = 129956, upload-time = "2026-08-04T18:15:27.159Z" },
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This is a workaround for Renovate not respecting the 30-day cooldown in our [shared Renovate config](https://github.com/astral-sh/renovate-config/blob/0146d963693a5335c975355d8383fe6933f5dc95/preset.json5#L46) for lockfile-update PRs such as #168, an open PR to update several Python packages in this repo's lockfile. [Renovate documents this limitation](https://docs.renovatebot.com/presets-security/#securityminimumreleaseagepypi): lockfile-maintenance updates delegate dependency resolution to the package manager without validating the minimum release age.

Set `exclude-newer = "P30D"` in `[tool.uv]` so uv enforces the cooldown when Renovate regenerates `uv.lock`. Exempt the pinned Astral packages, `ty` and `uv-build`, and link to the shared cooldown and Renovate limitation in the configuration comment.

Downgrade `setuptools` from 84.0.0 to 83.0.0 and `packaging` from 26.3 to 26.2 because the newer versions are still within the cooldown window.
