### PR TITLE
Enforce dependency cooldowns in the uv-lock hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -71,4 +71,4 @@ repos:
     hooks:
       - id: uv-lock
         priority: 0
-        args: [--default-index=https://pypi.org/simple]
+        args: [--default-index=https://pypi.org/simple, --refresh]


### PR DESCRIPTION
Pass `--refresh` to the `uv-lock` hook so it re-resolves dependencies and reapplies the configured cooldown instead of accepting an otherwise up-to-date lockfile.

This catches lockfile-only updates such as #168 that introduce releases inside the cooldown window. Existing eligible locked versions remain preferred; this does not opt into dependency upgrades.
