### PR TITLE
Replace GitPython with Git subprocess calls

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,6 @@ name = "ecosystem-analyzer"
 version = "0.1.0"
 description = "A tool for analyzing Python projects with ty"
 dependencies = [
-    "gitpython==3.1.59",
     "mypy-primer @ git+https://github.com/hauntsaninja/mypy_primer@3058720299b812c393ad926bcca96eede20fa683",
     "click==8.4.2",
     "jinja2==3.1.6",
@@ -113,8 +112,7 @@ prek = ["prek"]
 # https://github.com/astral-sh/renovate-config/blob/0146d963693a5335c975355d8383fe6933f5dc95/preset.json5#L46
 exclude-newer = "P30D"
 # Exempt the Astral tools pinned in this project.
-# Also exempt gitpython, which has a newer security release that we want to upgrade to.
-exclude-newer-package = { ty = false, uv-build = false, gitpython = false }
+exclude-newer-package = { ty = false, uv-build = false }
 no-build = true
 # The project is installed locally, and mypy-primer is pinned to Git.
 no-binary-package = ["ecosystem-analyzer", "mypy-primer"]

--- a/src/ecosystem_analyzer/config.py
+++ b/src/ecosystem_analyzer/config.py
@@ -1,4 +1,7 @@
-"""Configuration constants for the ecosystem analyzer."""
+"""Configuration defaults and cache paths for the ecosystem analyzer."""
+
+import os
+from pathlib import Path
 
 # Projects may require a newer Python version than this baseline.
 MINIMUM_PYTHON_VERSION = (3, 11)
@@ -9,3 +12,15 @@ UV_NO_BUILD_ENV = {
     "UV_NO_BUILD": "1",
     "UV_NO_BINARY": "0",
 }
+
+
+def get_cache_dir() -> Path:
+    """Get the XDG cache directory for ecosystem-analyzer."""
+    cache_home = os.environ.get("XDG_CACHE_HOME")
+    if cache_home:
+        cache_dir = Path(cache_home) / "ecosystem-analyzer"
+    else:
+        cache_dir = Path.home() / ".cache" / "ecosystem-analyzer"
+
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    return cache_dir

--- a/src/ecosystem_analyzer/git.py
+++ b/src/ecosystem_analyzer/git.py
@@ -4,9 +4,8 @@ import hashlib
 import logging
 from pathlib import Path
 
-from git import Commit, Repo
-
 from .installed_project import _get_cache_dir
+from .process import run
 
 logger = logging.getLogger(__name__)
 
@@ -18,50 +17,47 @@ def _ty_repo_cache_path(repo_path: Path) -> Path:
     return cache_dir / f"ty_{location_hash}"
 
 
-def _update_cached_repo(repo: Repo) -> None:
-    logger.debug("Updating cached ty repository")
-    repo.remote().fetch()
-
-
-def resolve_ty_repo(repo_path: str | Path) -> Repo:
-    """Return a Repo with a working tree, cloning bare repos into cache."""
+def resolve_ty_repo(repo_path: str | Path) -> Path:
+    """Return the working tree path, cloning bare repositories into cache."""
     resolved_path = Path(repo_path).expanduser().resolve()
-    repo = Repo(resolved_path)
-
-    if not repo.bare:
-        return repo
+    result = run("git", "rev-parse", "--is-bare-repository", cwd=resolved_path)
+    if result.strip() == "false":
+        result = run("git", "rev-parse", "--show-toplevel", cwd=resolved_path)
+        return Path(result.strip())
 
     cache_path = _ty_repo_cache_path(resolved_path)
 
     if cache_path.exists():
         logger.info(f"Using cached ty repository at {cache_path}")
-        cached_repo = Repo(cache_path)
     else:
         logger.info(f"Cloning bare ty repository from {resolved_path} to {cache_path}")
-        cached_repo = Repo.clone_from(resolved_path.as_posix(), cache_path)
+        run("git", "clone", "--", str(resolved_path), str(cache_path), cwd=Path.cwd())
 
-    try:
-        origin = cached_repo.remote()
-    except ValueError:
-        origin = cached_repo.create_remote("origin", resolved_path.as_posix())
-    else:
-        origin.set_url(resolved_path.as_posix())
+    remotes = run("git", "remote", cwd=cache_path).splitlines()
+    run(
+        "git",
+        "remote",
+        "set-url" if "origin" in remotes else "add",
+        "origin",
+        str(resolved_path),
+        cwd=cache_path,
+    )
+    logger.debug("Updating cached ty repository")
+    run("git", "fetch", "origin", cwd=cache_path)
+    return cache_path
 
-    _update_cached_repo(cached_repo)
-    return cached_repo
 
+def get_latest_ty_commits(repo: Path, num_commits: int) -> list[tuple[str, str]]:
+    """Return the latest ty commit SHAs and first message lines, oldest first."""
 
-def get_latest_ty_commits(repo: Repo, num_commits: int) -> list[Commit]:
-    """Return the latest ty commits in chronological order."""
+    run("git", "checkout", "origin/main", cwd=repo)
+    result = run("git", "log", "-z", "--format=%H%x00%B", cwd=repo)
 
-    repo.git.checkout("origin/main")
-
-    commits: list[Commit] = []
-    for commit in repo.iter_commits():
-        assert isinstance(commit.message, str)
-
-        if commit.message.startswith("[ty] "):
-            commits.append(commit)
+    commits: list[tuple[str, str]] = []
+    fields = result.removesuffix("\0").split("\0")
+    for sha, message in zip(fields[::2], fields[1::2], strict=True):
+        if message.startswith("[ty] "):
+            commits.append((sha, message.splitlines()[0]))
             if len(commits) >= num_commits:
                 break
 

--- a/src/ecosystem_analyzer/git.py
+++ b/src/ecosystem_analyzer/git.py
@@ -4,17 +4,26 @@ import hashlib
 import logging
 from pathlib import Path
 
-from .installed_project import _get_cache_dir
+from .config import get_cache_dir
 from .process import run
 
 logger = logging.getLogger(__name__)
 
 
 def _ty_repo_cache_path(repo_path: Path) -> Path:
-    cache_dir = _get_cache_dir()
+    cache_dir = get_cache_dir()
     repo_path = repo_path.resolve()
     location_hash = hashlib.sha256(repo_path.as_posix().encode()).hexdigest()[:12]
     return cache_dir / f"ty_{location_hash}"
+
+
+def validate_worktree(repo_path: Path) -> None:
+    """Require a working tree rooted at repo_path, not an enclosing repository."""
+    root = Path(
+        run("git", "rev-parse", "--show-toplevel", cwd=repo_path).removesuffix("\n")
+    )
+    if root.resolve() != repo_path.resolve():
+        raise ValueError(f"{repo_path} is not a Git working tree root (found {root})")
 
 
 def resolve_ty_repo(repo_path: str | Path) -> Path:
@@ -22,13 +31,14 @@ def resolve_ty_repo(repo_path: str | Path) -> Path:
     resolved_path = Path(repo_path).expanduser().resolve()
     result = run("git", "rev-parse", "--is-bare-repository", cwd=resolved_path)
     if result.strip() == "false":
-        result = run("git", "rev-parse", "--show-toplevel", cwd=resolved_path)
-        return Path(result.strip())
+        validate_worktree(resolved_path)
+        return resolved_path
 
     cache_path = _ty_repo_cache_path(resolved_path)
 
     if cache_path.exists():
         logger.info(f"Using cached ty repository at {cache_path}")
+        validate_worktree(cache_path)
     else:
         logger.info(f"Cloning bare ty repository from {resolved_path} to {cache_path}")
         run("git", "clone", "--", str(resolved_path), str(cache_path), cwd=Path.cwd())
@@ -51,7 +61,15 @@ def get_latest_ty_commits(repo: Path, num_commits: int) -> list[tuple[str, str]]
     """Return the latest ty commit SHAs and first message lines, oldest first."""
 
     run("git", "checkout", "origin/main", cwd=repo)
-    result = run("git", "log", "-z", "--format=%H%x00%B", cwd=repo)
+    result = run(
+        "git",
+        "log",
+        "--no-show-signature",
+        "--encoding=UTF-8",
+        "-z",
+        "--format=%H%x00%B",
+        cwd=repo,
+    )
 
     commits: list[tuple[str, str]] = []
     fields = result.removesuffix("\0").split("\0")

--- a/src/ecosystem_analyzer/installed_project.py
+++ b/src/ecosystem_analyzer/installed_project.py
@@ -10,22 +10,11 @@ from pathlib import Path
 
 from mypy_primer.model import Project
 
-from .config import MINIMUM_PYTHON_VERSION, UV_NO_BUILD_ENV
+from .config import MINIMUM_PYTHON_VERSION, UV_NO_BUILD_ENV, get_cache_dir
+from .git import validate_worktree
 from .process import run
 
 logger = logging.getLogger(__name__)
-
-
-def _get_cache_dir() -> Path:
-    """Get the XDG cache directory for ecosystem-analyzer."""
-    cache_home = os.environ.get("XDG_CACHE_HOME")
-    if cache_home:
-        cache_dir = Path(cache_home) / "ecosystem-analyzer"
-    else:
-        cache_dir = Path.home() / ".cache" / "ecosystem-analyzer"
-
-    cache_dir.mkdir(parents=True, exist_ok=True)
-    return cache_dir
 
 
 def _get_project_cache_path(project: Project) -> Path:
@@ -33,7 +22,7 @@ def _get_project_cache_path(project: Project) -> Path:
     # Use a hash of the location to create a unique directory name
     location_hash = hashlib.sha256(project.location.encode()).hexdigest()[:12]
     project_name = project.name_override or project.location.split("/")[-1]
-    cache_dir = _get_cache_dir()
+    cache_dir = get_cache_dir()
     return cache_dir / f"{project_name}_{location_hash}"
 
 
@@ -127,42 +116,38 @@ class InstalledProject:
         return self._project.ty_cmd
 
     def _clone_or_update(self) -> None:
-        try:
-            if self._cache_path.exists():
-                logger.info(f"Using cached repository at {self._cache_path}")
-                # Update the repository to latest
-                logger.debug("Updating cached repository")
-                run("git", "fetch", "--depth", "1", "origin", cwd=self._cache_path)
-                run("git", "reset", "--hard", "origin/HEAD", cwd=self._cache_path)
-                # Update submodules
-                run(
-                    "git",
-                    "submodule",
-                    "update",
-                    "--init",
-                    "--recursive",
-                    "--depth",
-                    "1",
-                    cwd=self._cache_path,
-                )
-            else:
-                logger.info(f"Cloning {self._project.location} into {self._cache_path}")
-                run(
-                    "git",
-                    "clone",
-                    "--recurse-submodules",
-                    "--depth",
-                    "1",
-                    "--",
-                    self._project.location,
-                    str(self._cache_path),
-                    cwd=Path.cwd(),
-                )
-        except (OSError, subprocess.CalledProcessError) as e:
-            logger.error(f"Error cloning/updating repository: {e}")
-            if isinstance(e, subprocess.CalledProcessError):
-                logger.error(e.stderr)
-            return
+        if self._cache_path.exists():
+            validate_worktree(self._cache_path)
+            logger.info(f"Using cached repository at {self._cache_path}")
+            # Update the repository to latest
+            logger.debug("Updating cached repository")
+            run("git", "fetch", "--depth", "1", "origin", cwd=self._cache_path)
+            run("git", "reset", "--hard", "origin/HEAD", cwd=self._cache_path)
+            # Update submodules
+            run(
+                "git",
+                "submodule",
+                "update",
+                "--checkout",
+                "--init",
+                "--recursive",
+                "--depth",
+                "1",
+                cwd=self._cache_path,
+            )
+        else:
+            logger.info(f"Cloning {self._project.location} into {self._cache_path}")
+            run(
+                "git",
+                "clone",
+                "--recurse-submodules",
+                "--depth",
+                "1",
+                "--",
+                self._project.location,
+                str(self._cache_path),
+                cwd=Path.cwd(),
+            )
 
         if self._exclude_newer is not None:
             self._pin_to_timestamp()
@@ -173,7 +158,14 @@ class InstalledProject:
 
         cutoff = validate_exclude_newer(self._exclude_newer)
         head_timestamp = run(
-            "git", "show", "--no-patch", "--format=%cI", "HEAD", cwd=self._cache_path
+            "git",
+            "show",
+            "--no-show-signature",
+            "--no-patch",
+            "--format=%cI",
+            "HEAD",
+            "--",
+            cwd=self._cache_path,
         ).strip()
         head_date = dt.datetime.fromisoformat(head_timestamp).astimezone(dt.UTC)
 

--- a/src/ecosystem_analyzer/installed_project.py
+++ b/src/ecosystem_analyzer/installed_project.py
@@ -8,10 +8,10 @@ import subprocess
 import tempfile
 from pathlib import Path
 
-from git import GitCommandError, GitError, Repo
 from mypy_primer.model import Project
 
 from .config import MINIMUM_PYTHON_VERSION, UV_NO_BUILD_ENV
+from .process import run
 
 logger = logging.getLogger(__name__)
 
@@ -64,8 +64,6 @@ def validate_exclude_newer(value: str) -> dt.datetime:
 class InstalledProject:
     """An ecosystem project with a cached checkout and isolated environment."""
 
-    _repo: Repo
-
     def __init__(self, project: Project, exclude_newer: str | None = None) -> None:
         self._project = project
         self._exclude_newer = exclude_newer
@@ -106,7 +104,9 @@ class InstalledProject:
     def default_branch(self) -> str:
         """The active branch of the cached project checkout."""
 
-        return self._repo.active_branch.name
+        return run(
+            "git", "symbolic-ref", "--short", "HEAD", cwd=self._cache_path
+        ).strip()
 
     @property
     def venv_path(self) -> Path:
@@ -118,9 +118,7 @@ class InstalledProject:
     def current_commit(self) -> str:
         """The commit SHA currently checked out for this project."""
 
-        commit = self._repo.head.commit.hexsha
-        assert isinstance(commit, str)
-        return commit
+        return run("git", "rev-parse", "HEAD", cwd=self._cache_path).strip()
 
     @property
     def ty_cmd(self) -> str | None:
@@ -132,27 +130,38 @@ class InstalledProject:
         try:
             if self._cache_path.exists():
                 logger.info(f"Using cached repository at {self._cache_path}")
-                self._repo = Repo(self._cache_path)
                 # Update the repository to latest
                 logger.debug("Updating cached repository")
-                self._repo.remote().fetch(depth=1)
-                self._repo.git.reset("--hard", "origin/HEAD")
+                run("git", "fetch", "--depth", "1", "origin", cwd=self._cache_path)
+                run("git", "reset", "--hard", "origin/HEAD", cwd=self._cache_path)
                 # Update submodules
-                for submodule in self._repo.submodules:
-                    submodule.update(
-                        recursive=True,
-                        clone_multi_options=["--depth", "1"],
-                    )
+                run(
+                    "git",
+                    "submodule",
+                    "update",
+                    "--init",
+                    "--recursive",
+                    "--depth",
+                    "1",
+                    cwd=self._cache_path,
+                )
             else:
                 logger.info(f"Cloning {self._project.location} into {self._cache_path}")
-                self._repo = Repo.clone_from(
-                    url=self._project.location,
-                    to_path=self._cache_path,
-                    recurse_submodules=True,
-                    depth=1,
+                run(
+                    "git",
+                    "clone",
+                    "--recurse-submodules",
+                    "--depth",
+                    "1",
+                    "--",
+                    self._project.location,
+                    str(self._cache_path),
+                    cwd=Path.cwd(),
                 )
-        except GitError as e:
+        except (OSError, subprocess.CalledProcessError) as e:
             logger.error(f"Error cloning/updating repository: {e}")
+            if isinstance(e, subprocess.CalledProcessError):
+                logger.error(e.stderr)
             return
 
         if self._exclude_newer is not None:
@@ -163,7 +172,10 @@ class InstalledProject:
         assert self._exclude_newer is not None
 
         cutoff = validate_exclude_newer(self._exclude_newer)
-        head_date = self._repo.head.commit.committed_datetime.astimezone(dt.UTC)
+        head_timestamp = run(
+            "git", "show", "--no-patch", "--format=%cI", "HEAD", cwd=self._cache_path
+        ).strip()
+        head_date = dt.datetime.fromisoformat(head_timestamp).astimezone(dt.UTC)
 
         if head_date <= cutoff:
             logger.debug(
@@ -179,23 +191,29 @@ class InstalledProject:
 
         # Deepen the shallow clone to find a commit before the cutoff
         try:
-            self._repo.git.fetch("--deepen", "20")
-        except GitError:
+            run("git", "fetch", "--deepen", "20", cwd=self._cache_path)
+        except subprocess.CalledProcessError:
             logger.warning(f"'{self.name}': failed to deepen clone, using HEAD as-is")
             return
 
         try:
-            commit_hash = self._repo.git.rev_list(
-                "HEAD", "--before", self._exclude_newer, "-1"
-            )
-        except GitError:
+            commit_hash = run(
+                "git",
+                "rev-list",
+                "HEAD",
+                "--before",
+                self._exclude_newer,
+                "-1",
+                cwd=self._cache_path,
+            ).strip()
+        except subprocess.CalledProcessError:
             logger.warning(
                 f"'{self.name}': failed to find commit before "
                 f"{self._exclude_newer}, using HEAD as-is"
             )
             return
 
-        if not commit_hash.strip():
+        if not commit_hash:
             logger.warning(
                 f"'{self.name}': no commit found before "
                 f"{self._exclude_newer}, using HEAD as-is"
@@ -206,7 +224,7 @@ class InstalledProject:
             f"'{self.name}': checking out {commit_hash[:12]} "
             f"(latest before {self._exclude_newer})"
         )
-        self._repo.git.checkout(commit_hash)
+        run("git", "checkout", commit_hash, cwd=self._cache_path)
 
     def _install_dependencies(self) -> None:
         # Create venv in temporary directory
@@ -280,16 +298,19 @@ class InstalledProject:
         # This marker search is intentionally approximate; ty still applies exclusions
         # and validates the metadata.
         try:
-            scripts = self._repo.git.grep(
+            scripts = run(
+                "git",
+                "grep",
                 "--files-with-matches",
                 "--null",
                 "--extended-regexp",
                 "^# /// script[[:space:]]*$",
                 "--",
                 *self.paths,
+                cwd=self._cache_path,
             )
-        except GitCommandError as error:
-            if error.status == 1:
+        except subprocess.CalledProcessError as error:
+            if error.returncode == 1:
                 return
             raise
 

--- a/src/ecosystem_analyzer/main.py
+++ b/src/ecosystem_analyzer/main.py
@@ -494,8 +494,7 @@ def history(
 
     last_commits = get_latest_ty_commits(repository, num_commits)
 
-    for commit in last_commits:
-        message = commit.message.splitlines()[0]
+    for _, message in last_commits:
         logger.debug(f"Found commit: {message}")
 
     ecosystem_projects = get_ecosystem_projects()
@@ -517,10 +516,8 @@ def history(
 
     statistics: list[CommitStatistics] = []
 
-    for idx, commit in enumerate(last_commits):
-        message = commit.message.splitlines()[0]
-        assert isinstance(message, str)
-        sha = commit.hexsha[:7]
+    for idx, (commit, message) in enumerate(last_commits):
+        sha = commit[:7]
         logger.debug(f"Analyzing commit: {message}")
 
         run_outputs = manager.run_for_commit(commit)

--- a/src/ecosystem_analyzer/manager.py
+++ b/src/ecosystem_analyzer/manager.py
@@ -6,7 +6,6 @@ import time
 from concurrent.futures import Future, ThreadPoolExecutor, as_completed
 from pathlib import Path
 
-from git import Commit, Repo
 from mypy_primer.model import Project
 from mypy_primer.projects import get_projects
 
@@ -44,7 +43,7 @@ class Manager:
     def __init__(
         self,
         *,
-        ty_repo: Repo | None = None,
+        ty_repo: Path | None = None,
         target_dir: Path | None,
         project_names: list[str],
         profile: str = "dev",
@@ -129,7 +128,7 @@ class Manager:
                 f" {install_total - wait_time:.1f}s overlapped with build)"
             )
 
-    def build(self, commit: str | Commit) -> None:
+    def build(self, commit: str) -> None:
         """Build ty for a commit. Can be called while projects are still installing."""
         self._ty.compile_for_commit(commit)
 
@@ -137,7 +136,7 @@ class Manager:
         """Use a pre-built ty binary instead of building from source."""
         self._ty.use_prebuilt(binary_path, commit_sha)
 
-    def run_for_commit(self, commit: str | Commit) -> list[RunOutput]:
+    def run_for_commit(self, commit: str) -> list[RunOutput]:
         """Build ty for a commit and run it on the installed projects.
 
         The build runs first and can overlap with background project

--- a/src/ecosystem_analyzer/process.py
+++ b/src/ecosystem_analyzer/process.py
@@ -5,7 +5,21 @@ from pathlib import Path
 
 
 def run(*args: str, cwd: Path) -> str:
-    """Run a command, returning its stdout unchanged and raising on failure."""
-    return subprocess.run(
-        list(args), cwd=cwd, check=True, capture_output=True, text=True
-    ).stdout
+    """Return a command's stdout, preserving stderr in exception tracebacks.
+
+    Use surrogate escapes to preserve non-UTF-8 paths and messages.
+    """
+    try:
+        return subprocess.run(
+            list(args),
+            cwd=cwd,
+            check=True,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="surrogateescape",
+        ).stdout
+    except subprocess.CalledProcessError as error:
+        if error.stderr:
+            error.add_note(error.stderr.rstrip())
+        raise

--- a/src/ecosystem_analyzer/process.py
+++ b/src/ecosystem_analyzer/process.py
@@ -1,0 +1,11 @@
+"""Shared subprocess helpers."""
+
+import subprocess
+from pathlib import Path
+
+
+def run(*args: str, cwd: Path) -> str:
+    """Run a command, returning its stdout unchanged and raising on failure."""
+    return subprocess.run(
+        list(args), cwd=cwd, check=True, capture_output=True, text=True
+    ).stdout

--- a/src/ecosystem_analyzer/schema.py
+++ b/src/ecosystem_analyzer/schema.py
@@ -3,7 +3,6 @@
 from pathlib import Path
 from typing import Literal, NotRequired
 
-from git import Repo
 from typing_extensions import TypedDict
 
 type DiagnosticLevel = Literal["error", "warning", "fatal"]
@@ -105,7 +104,7 @@ class RunData(TypedDict, closed=True):
 class CliContext(TypedDict, closed=True):
     """Shared Click context passed from the root command to its subcommands."""
 
-    repository: Repo | None
+    repository: Path | None
     target: Path | None
     verbose: bool
     flaky_runs: int

--- a/src/ecosystem_analyzer/ty.py
+++ b/src/ecosystem_analyzer/ty.py
@@ -10,12 +10,11 @@ import time
 from collections import Counter
 from pathlib import Path
 
-from git import Commit, Repo
-
 from .config import UV_NO_BUILD_ENV
 from .diagnostic import DiagnosticsParser, index_panic_messages
 from .flaky import classify_diagnostics
 from .installed_project import InstalledProject
+from .process import run
 from .schema import Diagnostic, ExitStatus, OutputVariant, RunOutput
 
 logger = logging.getLogger(__name__)
@@ -74,18 +73,18 @@ class Ty:
 
     def __init__(
         self,
-        repository: Repo | None = None,
+        repository: Path | None = None,
         target_dir: Path | None = None,
         profile: str = "dev",
     ) -> None:
-        self.repository: Repo | None = repository
+        self.repository: Path | None = repository
         if repository is not None:
-            self.working_dir: Path = Path(repository.working_dir)
+            self.working_dir: Path = repository
             self.cargo_target_dir: Path = target_dir or self.working_dir / "target"
         self.profile: str = profile
         self._commit_override: str | None = None
 
-    def compile_for_commit(self, commit: str | Commit) -> None:
+    def compile_for_commit(self, commit: str) -> None:
         """Check out the requested commit and build its ty executable."""
 
         if self.repository is None:
@@ -93,7 +92,7 @@ class Ty:
 
         # Checkout the commit
         logger.debug(f"Checking out ty commit '{commit}'")
-        self.repository.git.checkout(commit)
+        run("git", "checkout", commit, cwd=self.working_dir)
 
         # Compile ty
         env = os.environ.copy()
@@ -133,9 +132,7 @@ class Ty:
             raise RuntimeError(
                 "No commit SHA available: no repository and no prebuilt override set"
             )
-        sha = self.repository.head.commit.hexsha
-        assert isinstance(sha, str)
-        return sha
+        return run("git", "rev-parse", "HEAD", cwd=self.repository).strip()
 
     def run_on_project(self, project: InstalledProject) -> RunOutput:
         """Analyze one installed project and collect diagnostics and exit evidence."""

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -3,6 +3,7 @@
 import json
 import os
 import subprocess
+import traceback
 from pathlib import Path
 from unittest.mock import call, patch
 
@@ -10,24 +11,38 @@ import pytest
 from click.testing import CliRunner
 from mypy_primer.model import Project
 
-from ecosystem_analyzer.git import get_latest_ty_commits, resolve_ty_repo
-from ecosystem_analyzer.installed_project import InstalledProject
+from ecosystem_analyzer.git import (
+    _ty_repo_cache_path,
+    get_latest_ty_commits,
+    resolve_ty_repo,
+)
+from ecosystem_analyzer.installed_project import (
+    InstalledProject,
+    _get_project_cache_path,
+)
 from ecosystem_analyzer.main import cli
 from ecosystem_analyzer.process import run
 from ecosystem_analyzer.ty import Ty
 
 
 def _git(repo: Path, *args: str) -> str:
+    """Run Git in a test repository and strip surrounding output whitespace."""
     return run("git", *args, cwd=repo).strip()
 
 
 def _commit(repo: Path, message: str) -> str:
+    """Create a commit, even with no staged changes, and return its full SHA."""
     _git(repo, "commit", "--allow-empty", "-m", message)
     return _git(repo, "rev-parse", "HEAD")
 
 
 @pytest.fixture
 def repo(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Create a repository isolated from the user's Git configuration and caches.
+
+    Its path contains a space to exercise argument handling. Only local file
+    transports are allowed, so cloning cannot contact a network remote.
+    """
     monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path / "cache"))
     monkeypatch.setenv("GIT_CONFIG_GLOBAL", os.devnull)
     monkeypatch.setenv("GIT_CONFIG_NOSYSTEM", "1")
@@ -41,9 +56,30 @@ def repo(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     return path
 
 
+@pytest.fixture
+def signed_repo(repo: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Sign commits with a temporary SSH key and enable signature display.
+
+    Set log.showSignature globally so cloned repositories also request the
+    verification output that can interfere with parsing Git's stdout.
+    """
+    key = tmp_path / "signing_key"
+    run("ssh-keygen", "-q", "-t", "ed25519", "-N", "", "-f", str(key), cwd=tmp_path)
+    signers = tmp_path / "allowed_signers"
+    signers.write_text(f"test@example.com {key.with_suffix('.pub').read_text()}")
+    monkeypatch.setenv("GIT_CONFIG_GLOBAL", str(tmp_path / "gitconfig"))
+    _git(repo, "config", "--global", "log.showSignature", "true")
+    _git(repo, "config", "--global", "gpg.ssh.allowedSignersFile", str(signers))
+    _git(repo, "config", "gpg.format", "ssh")
+    _git(repo, "config", "user.signingKey", str(key))
+    _git(repo, "config", "commit.gpgSign", "true")
+    return repo
+
+
 def _install(
     repo: Path, *, exclude_newer: str | None = None, paths: list[str] | None = None
 ) -> InstalledProject:
+    """Prepare a real project checkout without installing Python dependencies."""
     project = Project(
         location=repo.as_uri(), mypy_cmd=None, pyright_cmd=None, paths=paths
     )
@@ -52,6 +88,12 @@ def _install(
 
 
 def test_resolve_linked_worktree(repo: Path, tmp_path: Path) -> None:
+    """Accept a linked worktree and read its checked-out commit.
+
+    A worktree created with `git worktree add --detach` has a .git file pointing
+    to shared metadata. Resolution must return that worktree's path, not the
+    main repository's path.
+    """
     sha = _commit(repo, "Initial commit")
     worktree = tmp_path / "linked worktree"
     _git(repo, "worktree", "add", "--detach", str(worktree), sha)
@@ -60,15 +102,122 @@ def test_resolve_linked_worktree(repo: Path, tmp_path: Path) -> None:
     assert Ty(repository=worktree).commit_sha == sha
 
 
+@pytest.mark.parametrize("suffix", [" ", "\n"], ids=["space", "newline"])
+def test_resolve_repository_preserves_trailing_whitespace(
+    repo: Path, tmp_path: Path, suffix: str
+) -> None:
+    r"""Preserve whitespace that is part of the repository directory's name.
+
+    For example, "source repo " and "source repo\n" must not resolve to the
+    sibling repository named "source repo", which contains a different commit.
+    """
+    _commit(repo, "Other repository")
+    intended = repo.with_name(repo.name + suffix)
+    _git(tmp_path, "init", "--initial-branch=main", str(intended))
+    sha = _commit(intended, "Intended repository")
+
+    resolved = resolve_ty_repo(intended)
+
+    assert resolved == intended
+    assert Ty(repository=resolved).commit_sha == sha
+
+
 def test_resolve_invalid_repository(tmp_path: Path) -> None:
-    with pytest.raises(subprocess.CalledProcessError):
+    """Reject a directory outside any repository and retain Git's error message.
+
+    The failure must keep Git's exit code 128 and include its stderr in the
+    formatted traceback, so a caller can see why repository discovery failed.
+    """
+    with pytest.raises(subprocess.CalledProcessError) as error:
         resolve_ty_repo(tmp_path)
+
+    assert error.value.returncode == 128
+    assert error.value.stderr.strip() in "".join(
+        traceback.format_exception(error.value)
+    )
+
+
+def test_resolve_rejects_repository_subdirectory(repo: Path) -> None:
+    """Reject a subdirectory instead of resolving it to an enclosing repository.
+
+    For example, `--repository parent/child` must not return `parent` simply
+    because Git searches upwards: a later checkout would modify the wrong repo.
+    """
+    subdirectory = repo / "child"
+    subdirectory.mkdir()
+
+    with pytest.raises(ValueError, match="not a Git working tree root"):
+        resolve_ty_repo(subdirectory)
+
+
+def test_failed_checkout_includes_git_error(repo: Path) -> None:
+    """Keep Git's explanation when checking out a missing ty revision fails.
+
+    `compile_for_commit("missing-revision")` must raise with Git's exit code 1
+    and expose its stderr in the formatted traceback.
+    """
+    _commit(repo, "Initial commit")
+
+    with pytest.raises(subprocess.CalledProcessError) as error:
+        Ty(repository=repo).compile_for_commit("missing-revision")
+
+    assert error.value.returncode == 1
+    assert error.value.stderr.strip() in "".join(
+        traceback.format_exception(error.value)
+    )
+
+
+@pytest.mark.parametrize("cache_type", ["project", "ty"])
+def test_invalid_cache_does_not_modify_parent_repository(
+    repo: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, cache_type: str
+) -> None:
+    """Reject cache directories that would make Git operate on a parent repo.
+
+    Put an empty cache directory inside another checkout, for both project and
+    ty caches. The enclosing checkout's HEAD, uncommitted file edit, and origin
+    URL must remain unchanged when cache validation fails.
+    """
+    (repo / "tracked.py").write_text("remote = 1\n")
+    _git(repo, "add", "tracked.py")
+    _commit(repo, "Remote commit")
+    parent = tmp_path / "parent"
+    _git(tmp_path, "clone", str(repo), str(parent))
+    local_commit = _commit(parent, "Local commit")
+    tracked_file = parent / "tracked.py"
+    tracked_file.write_text("local = 2\n")
+    monkeypatch.setenv("XDG_CACHE_HOME", str(parent / "cache"))
+
+    bare = tmp_path / "bare"
+    if cache_type == "project":
+        project = Project(location=repo.as_uri(), mypy_cmd=None, pyright_cmd=None)
+        cache_path = _get_project_cache_path(project)
+    else:
+        _git(tmp_path, "clone", "--bare", str(repo), str(bare))
+        cache_path = _ty_repo_cache_path(bare)
+    cache_path.mkdir()
+
+    if cache_type == "project":
+        with pytest.raises(ValueError, match="not a Git working tree root"):
+            _install(repo)
+    else:
+        with pytest.raises(ValueError, match="not a Git working tree root"):
+            resolve_ty_repo(bare)
+
+    assert _git(parent, "rev-parse", "HEAD") == local_commit
+    assert tracked_file.read_text() == "local = 2\n"
+    assert _git(parent, "remote", "get-url", "origin") == str(repo)
 
 
 @pytest.mark.parametrize("origin_state", ["unchanged", "missing", "wrong_url"])
 def test_resolve_bare_repository_refreshes_cache(
     repo: Path, tmp_path: Path, origin_state: str
 ) -> None:
+    """Clone a bare ty repository into a working tree and refresh the same cache.
+
+    After adding an upstream commit, resolution must fetch it into origin/main.
+    Cover an already-correct origin as well as a missing remote or one pointing
+    elsewhere; each case must end with origin pointing to the bare repository.
+    """
     first = _commit(repo, "Initial commit")
     bare = tmp_path / "bare repo"
     _git(tmp_path, "clone", "--bare", str(repo), str(bare))
@@ -93,6 +242,13 @@ def test_resolve_bare_repository_refreshes_cache(
 
 @pytest.mark.parametrize("num_commits", [1, 2, 10])
 def test_latest_ty_commits_filter_and_order(repo: Path, num_commits: int) -> None:
+    """Select recent ty commits from origin/main and return them oldest first.
+
+    Requesting two of three matches returns the second and third in that order;
+    requesting more than exist returns all three. Ignore a [ruff] commit whose
+    body mentions [ty], and a newer local commit outside origin/main. Return
+    only each message's first line, preserving non-ASCII text such as an em dash.
+    """
     first = _commit(repo, "[ty] First")
     _commit(repo, "[ruff] Unrelated\n\n[ty] Only mentioned in the body")
     second = _commit(repo, "[ty] Second — details\non the next line\n\nBody")
@@ -110,12 +266,50 @@ def test_latest_ty_commits_filter_and_order(repo: Path, num_commits: int) -> Non
 
 
 def test_latest_ty_commits_without_matches(repo: Path) -> None:
+    """Return an empty list when origin/main contains no ty commits.
+
+    For example, a history containing only "[ruff] Unrelated" produces [].
+    """
     sha = _commit(repo, "[ruff] Unrelated")
     _git(repo, "update-ref", "refs/remotes/origin/main", sha)
     assert get_latest_ty_commits(repo, 10) == []
 
 
+def test_latest_ty_commits_ignore_signatures(signed_repo: Path) -> None:
+    """Read signed commit messages without parsing signature-verification output.
+
+    With log.showSignature enabled, the result must still contain the commit's
+    full SHA and "[ty] Signed commit", without extra signature text or fields.
+    """
+    sha = _commit(signed_repo, "[ty] Signed commit")
+    _git(signed_repo, "update-ref", "refs/remotes/origin/main", sha)
+
+    assert get_latest_ty_commits(signed_repo, 1) == [(sha, "[ty] Signed commit")]
+
+
+def test_git_output_encoding(repo: Path) -> None:
+    """Read UTF-8 history even when Git is configured to emit Latin-1 messages.
+
+    "[ty] Café" must survive both checkout's stderr and the history log output.
+    A separate `run("git", "log", ...)` call must preserve Git's original
+    Latin-1 bytes through surrogate escapes when Git's encoding is not overridden.
+    """
+    sha = _commit(repo, "[ty] Café")
+    _git(repo, "update-ref", "refs/remotes/origin/main", sha)
+    _git(repo, "config", "i18n.logOutputEncoding", "ISO-8859-1")
+
+    assert get_latest_ty_commits(repo, 1) == [(sha, "[ty] Café")]
+    output = run("git", "log", "-1", "--format=%s", cwd=repo)
+    assert output.encode("utf-8", errors="surrogateescape") == b"[ty] Caf\xe9\n"
+
+
 def test_history_uses_commit_shas_and_messages(repo: Path, tmp_path: Path) -> None:
+    """Pass full SHAs to analysis and write abbreviated SHAs and subjects to JSON.
+
+    For two ty commits, the history CLI must call the mocked Manager oldest
+    first, using full hashes. Its JSON uses the first seven SHA characters and
+    the first message line, omitting a commit body such as "Body".
+    """
     first = _commit(repo, "[ty] First\n\nBody")
     second = _commit(repo, "[ty] Second")
     _git(repo, "update-ref", "refs/remotes/origin/main", second)
@@ -150,6 +344,12 @@ def test_history_uses_commit_shas_and_messages(repo: Path, tmp_path: Path) -> No
 
 
 def test_project_clone_and_update(repo: Path) -> None:
+    """Create a shallow project checkout and refresh that cache on reuse.
+
+    The first installation reports the main branch and its initial SHA. After
+    an upstream commit, another installation must reuse the same directory and
+    report the new SHA.
+    """
     first = _commit(repo, "Initial commit")
     project = _install(repo)
     assert project.current_commit == first
@@ -164,9 +364,57 @@ def test_project_clone_and_update(repo: Path) -> None:
     assert updated.current_commit == second
 
 
+def test_failed_submodule_clone_aborts_project_preparation(
+    repo: Path, tmp_path: Path
+) -> None:
+    """Abort preparation when a required submodule cannot be cloned.
+
+    The parent can be a valid checkout while module/module.py is missing. Both
+    the initial clone and a retry using that partial cache must raise; neither
+    attempt may proceed to installing Python dependencies.
+    """
+    child = tmp_path / "child"
+    _git(tmp_path, "init", "--initial-branch=main", str(child))
+    (child / "module.py").write_text("value: int = 'type error'\n")
+    _git(child, "add", "module.py")
+    _commit(child, "Submodule commit")
+    _git(repo, "submodule", "add", child.as_uri(), "module")
+    _git(
+        repo,
+        "config",
+        "--file",
+        ".gitmodules",
+        "submodule.module.url",
+        (tmp_path / "missing").as_uri(),
+    )
+    _git(repo, "add", ".gitmodules")
+    _commit(repo, "Unavailable submodule")
+    project = Project(location=repo.as_uri(), mypy_cmd=None, pyright_cmd=None)
+    cache_path = _get_project_cache_path(project)
+
+    with patch.object(InstalledProject, "_install_dependencies") as install:
+        with pytest.raises(subprocess.CalledProcessError):
+            InstalledProject(project)
+
+        assert (cache_path / ".git").is_dir()
+        assert not (cache_path / "module" / "module.py").exists()
+
+        # Retrying must not treat the partial checkout as a usable cache.
+        with pytest.raises(subprocess.CalledProcessError):
+            InstalledProject(project)
+
+    install.assert_not_called()
+
+
 def test_project_clone_and_update_recursive_submodules(
     repo: Path, tmp_path: Path
 ) -> None:
+    """Populate and refresh submodules nested two levels deep.
+
+    For a parent -> child -> leaf layout, cloning must include the leaf's file.
+    After each parent records its child's new commit, refreshing the cache must
+    update the leaf's module.py from "first = 1" to "second = 2".
+    """
     leaf = tmp_path / "leaf"
     _git(tmp_path, "init", "--initial-branch=main", str(leaf))
     (leaf / "module.py").write_text("first = 1\n")
@@ -202,6 +450,51 @@ def test_project_clone_and_update_recursive_submodules(
     assert cached_module.read_text() == "second = 2\n"
 
 
+@pytest.mark.parametrize("update_strategy", ["merge", "rebase"])
+def test_project_submodule_update_checks_out_recorded_commit(
+    repo: Path, tmp_path: Path, update_strategy: str
+) -> None:
+    """Use the recorded submodule commit, ignoring merge/rebase update strategies.
+
+    Replace the child's main branch with unrelated history and have the parent
+    record the new SHA. Even with update=merge or update=rebase in .gitmodules,
+    refreshing the cache must check out that SHA without merging or replaying
+    the old commit.
+    """
+    child = tmp_path / "child"
+    _git(tmp_path, "init", "--initial-branch=main", str(child))
+    (child / "module.py").write_text("value = 1\n")
+    _git(child, "add", "module.py")
+    _commit(child, "Initial child")
+    _git(repo, "submodule", "add", child.as_uri(), "module")
+    _git(
+        repo,
+        "config",
+        "--file",
+        ".gitmodules",
+        "submodule.module.update",
+        update_strategy,
+    )
+    _git(repo, "add", ".gitmodules")
+    _commit(repo, "Initial parent")
+    project = _install(repo)
+
+    # The recorded commit can move to a different history after a force-push.
+    _git(child, "checkout", "--orphan", "replacement")
+    (child / "module.py").write_text("value = 2\n")
+    _git(child, "add", "module.py")
+    new_child = _commit(child, "Replacement child")
+    _git(child, "branch", "-M", "main")
+    _git(repo / "module", "fetch", "origin")
+    _git(repo / "module", "checkout", new_child)
+    _git(repo, "add", "module")
+    _commit(repo, "Update parent")
+
+    project._clone_or_update()
+
+    assert _git(project.root_directory / "module", "rev-parse", "HEAD") == new_child
+
+
 @pytest.mark.parametrize(
     ("cutoff", "use_first"),
     [
@@ -214,6 +507,13 @@ def test_project_clone_and_update_recursive_submodules(
 def test_project_timestamp_pinning(
     repo: Path, monkeypatch: pytest.MonkeyPatch, cutoff: str, use_first: bool
 ) -> None:
+    """Pin using timezone-aware committer dates, not the earlier author dates.
+
+    Both commits were authored in March but committed in April. An April 8
+    cutoff selects the first; a cutoff exactly at the second commit's timestamp
+    (April 9 at 22:00 UTC) selects the second. Keep HEAD when it already meets
+    the cutoff, or when neither commit is old enough.
+    """
     monkeypatch.setenv("GIT_AUTHOR_DATE", "2026-03-01T00:00:00Z")
     monkeypatch.setenv("GIT_COMMITTER_DATE", "2026-04-01T00:00:00Z")
     first = _commit(repo, "Before cutoff")
@@ -224,9 +524,52 @@ def test_project_timestamp_pinning(
     assert project.current_commit == (first if use_first else second)
 
 
+def test_project_timestamp_pinning_with_head_file(
+    repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Read HEAD's committer date even when a tracked file is also named HEAD.
+
+    With an April 1 commit and an April 2 cutoff, preparation must keep the
+    current commit. Git must interpret HEAD as the revision when reading its
+    date, without rejecting the name as ambiguous with the tracked file.
+    """
+    (repo / "HEAD").write_text("A tracked file named HEAD.\n")
+    _git(repo, "add", "HEAD")
+    monkeypatch.setenv("GIT_COMMITTER_DATE", "2026-04-01T00:00:00Z")
+    sha = _commit(repo, "Add file named HEAD")
+
+    project = _install(repo, exclude_newer="2026-04-02T00:00:00Z")
+
+    assert project.current_commit == sha
+
+
+def test_project_timestamp_pinning_ignores_signatures(
+    signed_repo: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Parse committer dates without Git's signature-verification output.
+
+    Given signed commits on April 1 and April 10, an April 8 cutoff must select
+    the April 1 commit even when global log.showSignature is enabled.
+    """
+    monkeypatch.setenv("GIT_COMMITTER_DATE", "2026-04-01T00:00:00Z")
+    first = _commit(signed_repo, "Before cutoff")
+    monkeypatch.setenv("GIT_COMMITTER_DATE", "2026-04-10T00:00:00Z")
+    _commit(signed_repo, "After cutoff")
+
+    project = _install(signed_repo, exclude_newer="2026-04-08T00:00:00Z")
+
+    assert project.current_commit == first
+
+
 def test_project_timestamp_pinning_failed_fetch(
     repo: Path, tmp_path: Path, caplog: pytest.LogCaptureFixture
 ) -> None:
+    """Warn and keep HEAD if fetching older history for timestamp pinning fails.
+
+    Start with a valid checkout, request a cutoff before HEAD, and point origin
+    at a missing repository. Failure to deepen the clone must leave the current
+    commit in place and log the fallback, without raising.
+    """
     sha = _commit(repo, "Initial commit")
     project = _install(repo)
     project._exclude_newer = "2000-01-01T00:00:00Z"
@@ -244,6 +587,13 @@ def test_project_timestamp_pinning_failed_fetch(
 def test_script_discovery(
     repo: Path, monkeypatch: pytest.MonkeyPatch, paths: list[str] | None
 ) -> None:
+    r"""Discover tracked inline Python scripts without changing their filenames.
+
+    Names include " leading space.py", "a\nnewline.py", and "café.pyi". Select
+    only .py/.pyi files containing the "# /// script" marker, ignore untracked
+    files, and honor an optional restriction to the scripts directory. Check
+    that both dependency-sync calls receive each selected script's exact path.
+    """
     script_names = ["a space.py", "a\nnewline.py", "café.pyi"]
     scripts = repo / "scripts"
     scripts.mkdir()
@@ -271,6 +621,11 @@ def test_script_discovery(
 
 
 def test_script_discovery_without_matches(repo: Path) -> None:
+    """Skip dependency synchronization when Git finds no inline scripts.
+
+    Git grep's exit code 1 is a normal no-match result: only the grep command
+    should run, without starting any dependency-sync subprocesses.
+    """
     _commit(repo, "No scripts")
     project = _install(repo)
 
@@ -283,6 +638,11 @@ def test_script_discovery_without_matches(repo: Path) -> None:
 
 
 def test_script_discovery_reports_git_errors(repo: Path, tmp_path: Path) -> None:
+    """Propagate Git discovery failures instead of treating them as no matches.
+
+    Running git grep outside a repository must raise with exit code 128, unlike
+    the expected exit code 1 when a valid repository has no matching scripts.
+    """
     _commit(repo, "Initial commit")
     project = _install(repo)
     project._cache_path = tmp_path

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -1,0 +1,293 @@
+"""Test Git operations against isolated local repositories."""
+
+import json
+import os
+import subprocess
+from pathlib import Path
+from unittest.mock import call, patch
+
+import pytest
+from click.testing import CliRunner
+from mypy_primer.model import Project
+
+from ecosystem_analyzer.git import get_latest_ty_commits, resolve_ty_repo
+from ecosystem_analyzer.installed_project import InstalledProject
+from ecosystem_analyzer.main import cli
+from ecosystem_analyzer.process import run
+from ecosystem_analyzer.ty import Ty
+
+
+def _git(repo: Path, *args: str) -> str:
+    return run("git", *args, cwd=repo).strip()
+
+
+def _commit(repo: Path, message: str) -> str:
+    _git(repo, "commit", "--allow-empty", "-m", message)
+    return _git(repo, "rev-parse", "HEAD")
+
+
+@pytest.fixture
+def repo(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    monkeypatch.setenv("XDG_CACHE_HOME", str(tmp_path / "cache"))
+    monkeypatch.setenv("GIT_CONFIG_GLOBAL", os.devnull)
+    monkeypatch.setenv("GIT_CONFIG_NOSYSTEM", "1")
+    monkeypatch.setenv("GIT_AUTHOR_NAME", "Test")
+    monkeypatch.setenv("GIT_AUTHOR_EMAIL", "test@example.com")
+    monkeypatch.setenv("GIT_COMMITTER_NAME", "Test")
+    monkeypatch.setenv("GIT_COMMITTER_EMAIL", "test@example.com")
+    monkeypatch.setenv("GIT_ALLOW_PROTOCOL", "file")
+    path = tmp_path / "source repo"
+    _git(tmp_path, "init", "--initial-branch=main", str(path))
+    return path
+
+
+def _install(
+    repo: Path, *, exclude_newer: str | None = None, paths: list[str] | None = None
+) -> InstalledProject:
+    project = Project(
+        location=repo.as_uri(), mypy_cmd=None, pyright_cmd=None, paths=paths
+    )
+    with patch.object(InstalledProject, "_install_dependencies"):
+        return InstalledProject(project, exclude_newer=exclude_newer)
+
+
+def test_resolve_linked_worktree(repo: Path, tmp_path: Path) -> None:
+    sha = _commit(repo, "Initial commit")
+    worktree = tmp_path / "linked worktree"
+    _git(repo, "worktree", "add", "--detach", str(worktree), sha)
+
+    assert resolve_ty_repo(worktree) == worktree
+    assert Ty(repository=worktree).commit_sha == sha
+
+
+def test_resolve_invalid_repository(tmp_path: Path) -> None:
+    with pytest.raises(subprocess.CalledProcessError):
+        resolve_ty_repo(tmp_path)
+
+
+@pytest.mark.parametrize("origin_state", ["unchanged", "missing", "wrong_url"])
+def test_resolve_bare_repository_refreshes_cache(
+    repo: Path, tmp_path: Path, origin_state: str
+) -> None:
+    first = _commit(repo, "Initial commit")
+    bare = tmp_path / "bare repo"
+    _git(tmp_path, "clone", "--bare", str(repo), str(bare))
+
+    cached = resolve_ty_repo(bare)
+    assert cached != bare
+    assert _git(cached, "rev-parse", "--is-bare-repository") == "false"
+    assert _git(cached, "rev-parse", "HEAD") == first
+
+    if origin_state == "missing":
+        _git(cached, "remote", "remove", "origin")
+    elif origin_state == "wrong_url":
+        _git(cached, "remote", "set-url", "origin", str(tmp_path / "missing"))
+
+    second = _commit(repo, "New commit")
+    _git(bare, "fetch", str(repo), "main:main")
+
+    assert resolve_ty_repo(bare) == cached
+    assert _git(cached, "remote", "get-url", "origin") == str(bare)
+    assert _git(cached, "rev-parse", "origin/main") == second
+
+
+@pytest.mark.parametrize("num_commits", [1, 2, 10])
+def test_latest_ty_commits_filter_and_order(repo: Path, num_commits: int) -> None:
+    first = _commit(repo, "[ty] First")
+    _commit(repo, "[ruff] Unrelated\n\n[ty] Only mentioned in the body")
+    second = _commit(repo, "[ty] Second — details\non the next line\n\nBody")
+    third = _commit(repo, "[ty] Third")
+    _git(repo, "update-ref", "refs/remotes/origin/main", third)
+    _commit(repo, "[ty] Local commit outside origin/main")
+
+    expected = [
+        (first, "[ty] First"),
+        (second, "[ty] Second — details"),
+        (third, "[ty] Third"),
+    ]
+    assert get_latest_ty_commits(repo, num_commits) == expected[-num_commits:]
+    assert _git(repo, "rev-parse", "HEAD") == third
+
+
+def test_latest_ty_commits_without_matches(repo: Path) -> None:
+    sha = _commit(repo, "[ruff] Unrelated")
+    _git(repo, "update-ref", "refs/remotes/origin/main", sha)
+    assert get_latest_ty_commits(repo, 10) == []
+
+
+def test_history_uses_commit_shas_and_messages(repo: Path, tmp_path: Path) -> None:
+    first = _commit(repo, "[ty] First\n\nBody")
+    second = _commit(repo, "[ty] Second")
+    _git(repo, "update-ref", "refs/remotes/origin/main", second)
+    output = tmp_path / "history.json"
+
+    with (
+        patch("ecosystem_analyzer.main.Manager") as manager_class,
+        patch("ecosystem_analyzer.main.get_ecosystem_projects", return_value={}),
+    ):
+        manager = manager_class.return_value
+        manager.run_for_commit.return_value = [{"diagnostics": []}]
+        result = CliRunner().invoke(
+            cli, ["--repository", str(repo), "history", "--output", str(output)]
+        )
+
+    assert result.exit_code == 0, result.output
+    assert manager.run_for_commit.call_args_list == [call(first), call(second)]
+    assert json.loads(output.read_text()) == {
+        "statistics": [
+            {
+                "commit": first[:7],
+                "commit_message": "[ty] First",
+                "total_diagnostics": 0,
+            },
+            {
+                "commit": second[:7],
+                "commit_message": "[ty] Second",
+                "total_diagnostics": 0,
+            },
+        ]
+    }
+
+
+def test_project_clone_and_update(repo: Path) -> None:
+    first = _commit(repo, "Initial commit")
+    project = _install(repo)
+    assert project.current_commit == first
+    assert project.default_branch == "main"
+    assert (
+        _git(project.root_directory, "rev-parse", "--is-shallow-repository") == "true"
+    )
+
+    second = _commit(repo, "New commit")
+    updated = _install(repo)
+    assert updated.root_directory == project.root_directory
+    assert updated.current_commit == second
+
+
+def test_project_clone_and_update_recursive_submodules(
+    repo: Path, tmp_path: Path
+) -> None:
+    leaf = tmp_path / "leaf"
+    _git(tmp_path, "init", "--initial-branch=main", str(leaf))
+    (leaf / "module.py").write_text("first = 1\n")
+    _git(leaf, "add", "module.py")
+    _commit(leaf, "Initial leaf")
+
+    child = tmp_path / "child"
+    _git(tmp_path, "init", "--initial-branch=main", str(child))
+    _git(child, "submodule", "add", leaf.as_uri(), "nested leaf")
+    _commit(child, "Initial child")
+    _git(repo, "submodule", "add", child.as_uri(), "nested child")
+    _commit(repo, "Initial parent")
+
+    project = _install(repo)
+    cached_module = (
+        project.root_directory / "nested child" / "nested leaf" / "module.py"
+    )
+    assert cached_module.read_text() == "first = 1\n"
+
+    (leaf / "module.py").write_text("second = 2\n")
+    _git(leaf, "add", "module.py")
+    new_leaf = _commit(leaf, "Update leaf")
+    _git(child / "nested leaf", "fetch", "origin")
+    _git(child / "nested leaf", "checkout", new_leaf)
+    _git(child, "add", "nested leaf")
+    new_child = _commit(child, "Update child")
+    _git(repo / "nested child", "fetch", "origin")
+    _git(repo / "nested child", "checkout", new_child)
+    _git(repo, "add", "nested child")
+    _commit(repo, "Update parent")
+
+    project._clone_or_update()
+    assert cached_module.read_text() == "second = 2\n"
+
+
+@pytest.mark.parametrize(
+    ("cutoff", "use_first"),
+    [
+        ("2026-04-08T00:00:00Z", True),
+        ("2026-04-09T22:00:00Z", False),
+        ("2026-04-11T00:00:00Z", False),
+        ("2026-03-01T00:00:00Z", False),
+    ],
+)
+def test_project_timestamp_pinning(
+    repo: Path, monkeypatch: pytest.MonkeyPatch, cutoff: str, use_first: bool
+) -> None:
+    monkeypatch.setenv("GIT_AUTHOR_DATE", "2026-03-01T00:00:00Z")
+    monkeypatch.setenv("GIT_COMMITTER_DATE", "2026-04-01T00:00:00Z")
+    first = _commit(repo, "Before cutoff")
+    monkeypatch.setenv("GIT_COMMITTER_DATE", "2026-04-10T00:00:00+02:00")
+    second = _commit(repo, "After cutoff")
+
+    project = _install(repo, exclude_newer=cutoff)
+    assert project.current_commit == (first if use_first else second)
+
+
+def test_project_timestamp_pinning_failed_fetch(
+    repo: Path, tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    sha = _commit(repo, "Initial commit")
+    project = _install(repo)
+    project._exclude_newer = "2000-01-01T00:00:00Z"
+    _git(
+        project.root_directory, "remote", "set-url", "origin", str(tmp_path / "missing")
+    )
+
+    project._pin_to_timestamp()
+
+    assert project.current_commit == sha
+    assert "failed to deepen clone, using HEAD as-is" in caplog.text
+
+
+@pytest.mark.parametrize("paths", [None, ["scripts"]])
+def test_script_discovery(
+    repo: Path, monkeypatch: pytest.MonkeyPatch, paths: list[str] | None
+) -> None:
+    script_names = ["a space.py", "a\nnewline.py", "café.pyi"]
+    scripts = repo / "scripts"
+    scripts.mkdir()
+    for name in [*script_names, "notes.md"]:
+        (scripts / name).write_text("# /// script\n")
+    (scripts / "ordinary.py").write_text("x = 1\n")
+    (repo / " leading space.py").write_text("# /// script\n")
+    _git(repo, "add", ".")
+    _commit(repo, "Add scripts")
+    project = _install(repo, paths=paths)
+    (project.root_directory / "scripts" / "untracked.py").write_text("# /// script\n")
+    monkeypatch.setenv("UV", "true")
+
+    with patch(
+        "ecosystem_analyzer.installed_project.subprocess.run", wraps=subprocess.run
+    ) as run:
+        project._install_script_dependencies()
+
+    sync_commands = [c.args[0] for c in run.call_args_list if c.args[0][0] == "true"]
+    expected = {str(project.root_directory / "scripts" / name) for name in script_names}
+    if paths is None:
+        expected.add(str(project.root_directory / " leading space.py"))
+    assert len(sync_commands) == 2 * len(expected)
+    assert {cmd[cmd.index("--script") + 1] for cmd in sync_commands} == expected
+
+
+def test_script_discovery_without_matches(repo: Path) -> None:
+    _commit(repo, "No scripts")
+    project = _install(repo)
+
+    with patch(
+        "ecosystem_analyzer.installed_project.subprocess.run", wraps=subprocess.run
+    ) as run:
+        project._install_script_dependencies()
+
+    assert run.call_count == 1
+
+
+def test_script_discovery_reports_git_errors(repo: Path, tmp_path: Path) -> None:
+    _commit(repo, "Initial commit")
+    project = _install(repo)
+    project._cache_path = tmp_path
+
+    with pytest.raises(subprocess.CalledProcessError) as error:
+        project._install_script_dependencies()
+
+    assert error.value.returncode == 128

--- a/tests/test_sharding.py
+++ b/tests/test_sharding.py
@@ -2,10 +2,10 @@ from pathlib import Path
 
 import pytest
 from click.testing import CliRunner, Result
-from git import Repo
 from mypy_primer.model import Project
 
 from ecosystem_analyzer.main import cli, get_all_project_names, shard_projects
+from ecosystem_analyzer.process import run
 from ecosystem_analyzer.ty import Ty
 
 
@@ -150,7 +150,7 @@ def test_flaky_projects_cost_multiplied_by_flaky_runs() -> None:
 
 def _invoke_diff(tmp_path: Path, extra_args: list[str]) -> Result:
     """Invoke the `diff` subcommand with minimal valid required args."""
-    Repo.init(tmp_path)
+    run("git", "init", str(tmp_path), cwd=tmp_path)
     runner = CliRunner()
     return runner.invoke(
         cli,
@@ -220,12 +220,24 @@ def test_commit_sha_without_repo_or_override_raises() -> None:
 
 def test_commit_sha_falls_back_to_repo(tmp_path: Path) -> None:
     """Without an override, commit_sha reads from the repository HEAD."""
-    repo = Repo.init(tmp_path)
-    (tmp_path / "f.txt").write_text("x")
-    repo.index.add(["f.txt"])
-    repo.index.commit("init")
-    ty = Ty(repository=repo)
-    assert ty.commit_sha == repo.head.commit.hexsha
+    run("git", "init", str(tmp_path), cwd=tmp_path)
+    run(
+        "git",
+        "-c",
+        "user.name=Test",
+        "-c",
+        "user.email=test@example.com",
+        "-c",
+        "commit.gpgsign=false",
+        "commit",
+        "--allow-empty",
+        "-m",
+        "init",
+        cwd=tmp_path,
+    )
+    sha = run("git", "rev-parse", "HEAD", cwd=tmp_path).strip()
+    ty = Ty(repository=tmp_path)
+    assert ty.commit_sha == sha
 
 
 def test_diff_without_repository_requires_prebuilt_binaries() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -8,7 +8,6 @@ exclude-newer-span = "P30D"
 
 [options.exclude-newer-package]
 uv-build = false
-gitpython = false
 ty = false
 
 [manifest]
@@ -44,7 +43,6 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
-    { name = "gitpython" },
     { name = "jinja2" },
     { name = "mypy-primer" },
     { name = "typing-extensions" },
@@ -62,7 +60,6 @@ prek = [
 [package.metadata]
 requires-dist = [
     { name = "click", specifier = "==8.4.2" },
-    { name = "gitpython", specifier = "==3.1.59" },
     { name = "jinja2", specifier = "==3.1.6" },
     { name = "mypy-primer", git = "https://github.com/hauntsaninja/mypy_primer?rev=3058720299b812c393ad926bcca96eede20fa683" },
     { name = "typing-extensions", specifier = ">=4.16.0" },
@@ -74,30 +71,6 @@ dev = [
     { name = "ty", specifier = "==0.0.75" },
 ]
 prek = [{ name = "prek" }]
-
-[[package]]
-name = "gitdb"
-version = "4.0.12"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "smmap" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/72/94/63b0fc47eb32792c7ba1fe1b694daec9a63620db1e313033d18140c2320a/gitdb-4.0.12.tar.gz", hash = "sha256:5ef71f855d191a3326fcfbc0d5da835f26b13fbcba60c32c21091c349ffdb571", size = 394684, upload-time = "2025-01-02T07:20:46.413Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a0/61/5c78b91c3143ed5c14207f463aecfc8f9dbb5092fb2869baf37c273b2705/gitdb-4.0.12-py3-none-any.whl", hash = "sha256:67073e15955400952c6565cc3e707c554a4eea2e428946f7a4c162fab9bd9bcf", size = 62794, upload-time = "2025-01-02T07:20:43.624Z" },
-]
-
-[[package]]
-name = "gitpython"
-version = "3.1.59"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "gitdb" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/ca/dc/126b28e76b24a9268ba931ad3e012f71ebdadf62fd9f17758f7074bb0b20/gitpython-3.1.59.tar.gz", hash = "sha256:0a1475cfdc38a5bfba1a3e9a4a9da52a39749ecec322b772915c019f94e5b7e4", size = 230445, upload-time = "2026-08-10T12:03:20.271Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/ef/ed/ae57eb7d344f43f87b74b3a281ead6ec7d6394eef72a7b1dcb28dd089550/gitpython-3.1.59-py3-none-any.whl", hash = "sha256:67a82f537384578643624c8b2c531938a9b82be431663e575dcf638526631d4c", size = 220996, upload-time = "2026-08-10T12:03:18.804Z" },
-]
 
 [[package]]
 name = "iniconfig"
@@ -242,15 +215,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
-]
-
-[[package]]
-name = "smmap"
-version = "5.0.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/1f/ea/49c993d6dfdd7338c9b1000a0f36817ed7ec84577ae2e52f890d1a4ff909/smmap-5.0.3.tar.gz", hash = "sha256:4d9debb8b99007ae47165abc08670bd74cb74b5227dda7f643eccc4e9eb5642c", size = 22506, upload-time = "2026-03-09T03:43:26.1Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c1/d4/59e74daffcb57a07668852eeeb6035af9f32cbfd7a1d2511f17d2fe6a738/smmap-5.0.3-py3-none-any.whl", hash = "sha256:c106e05d5a61449cf6ba9a1e650227ecfb141590d2a98412103ff35d89fc7b2f", size = 24390, upload-time = "2026-03-09T03:43:24.361Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
We use GitPython for a small set of repository operations. Replace those uses with explicit Git subprocess calls, removing GitPython, gitdb and smmap from our dependencies and reducing the amount of third-party Git parsing code we rely on.

Repositories are represented by paths and commits by SHA strings. A shared subprocess helper returns stdout and keeps Git's stderr visible when commands fail. Repository roots are validated before updates, failed clones or updates stop project preparation, and submodules are checked out at the commits recorded by their parents. Metadata queries use explicit formats and encoding so Git's signature-display and message-encoding settings do not break parsing.

CLI options and report schemas are unchanged. Native Git, repository configuration and project installation commands remain trusted.
