### PR TITLE
Escape HTML in diagnostic and timing reports

### DIFF
--- a/src/ecosystem_analyzer/diff.py
+++ b/src/ecosystem_analyzer/diff.py
@@ -1873,13 +1873,17 @@ class DiagnosticDiff:
         # Set up Jinja2 environment with package loader
         try:
             # Try PackageLoader first (works for installed packages)
-            env = Environment(loader=PackageLoader("ecosystem_analyzer", "templates"))
+            env = Environment(
+                loader=PackageLoader("ecosystem_analyzer", "templates"), autoescape=True
+            )
         except (ImportError, FileNotFoundError):
             # Fallback to FileSystemLoader for development
             template_path = Path(__file__).parent.parent.parent / "templates"
             if not template_path.exists():
                 template_path = Path("templates")
-            env = Environment(loader=FileSystemLoader(str(template_path)))
+            env = Environment(
+                loader=FileSystemLoader(str(template_path)), autoescape=True
+            )
 
         template = env.get_template("diff.html")
 
@@ -1934,13 +1938,17 @@ class DiagnosticDiff:
         # Set up Jinja2 environment with package loader
         try:
             # Try PackageLoader first (works for installed packages)
-            env = Environment(loader=PackageLoader("ecosystem_analyzer", "templates"))
+            env = Environment(
+                loader=PackageLoader("ecosystem_analyzer", "templates"), autoescape=True
+            )
         except (ImportError, FileNotFoundError):
             # Fallback to FileSystemLoader for development
             template_path = Path(__file__).parent.parent.parent / "templates"
             if not template_path.exists():
                 template_path = Path("templates")
-            env = Environment(loader=FileSystemLoader(str(template_path)))
+            env = Environment(
+                loader=FileSystemLoader(str(template_path)), autoescape=True
+            )
 
         template = env.get_template("timing_diff.html")
 

--- a/src/ecosystem_analyzer/templates/diff.html
+++ b/src/ecosystem_analyzer/templates/diff.html
@@ -803,7 +803,7 @@
                             {% endfor %}
                             <tr class="show-more-row">
                                 <td colspan="4" style="text-align: center; padding: 8px;">
-                                    <button class="show-more-btn" onclick="toggleProjectRows(this)">
+                                    <button class="show-more-btn">
                                         Show {{ statistics.merged_by_project|length - 20 }} more projects
                                     </button>
                                 </td>
@@ -1001,7 +1001,7 @@
             <div class="file">
                 <div class="file-header-with-copy">
                     <h4 style="margin: 0;">{{ path }}</h4>
-                    <button class="copy-btn" onclick="copyPath(this, '{{ path }}')">📋</button>
+                    <button class="copy-btn" data-copy-path="{{ path }}">📋</button>
                 </div>
                 {% for diag in diagnostics %}
                 {{ render_diagnostic(diag, "added", project.project) }}
@@ -1023,7 +1023,7 @@
             <div class="file">
                 <div class="file-header-with-copy">
                     <h4 style="margin: 0;">{{ path }}</h4>
-                    <button class="copy-btn" onclick="copyPath(this, '{{ path }}')">📋</button>
+                    <button class="copy-btn" data-copy-path="{{ path }}">📋</button>
                 </div>
                 {% for diag in diagnostics %}
                 {{ render_diagnostic(diag, "removed", project.project) }}
@@ -1043,7 +1043,7 @@
             <div class="file added">
                 <div class="file-header-with-copy">
                     <h4 style="margin: 0;">{{ file_data.path }}</h4>
-                    <button class="copy-btn" onclick="copyPath(this, '{{ file_data.path }}')">📋</button>
+                    <button class="copy-btn" data-copy-path="{{ file_data.path }}">📋</button>
                 </div>
                 {% for diag in file_data.diagnostics %}
                 {{ render_diagnostic(diag, "added", project.project) }}
@@ -1063,7 +1063,7 @@
             <div class="file removed">
                 <div class="file-header-with-copy">
                     <h4 style="margin: 0;">{{ file_data.path }}</h4>
-                    <button class="copy-btn" onclick="copyPath(this, '{{ file_data.path }}')">📋</button>
+                    <button class="copy-btn" data-copy-path="{{ file_data.path }}">📋</button>
                 </div>
                 {% for diag in file_data.diagnostics %}
                 {{ render_diagnostic(diag, "removed", project.project) }}
@@ -1083,7 +1083,7 @@
             <div class="file modified">
                 <div class="file-header-with-copy">
                     <h4 style="margin: 0;">{{ file_data.path }}</h4>
-                    <button class="copy-btn" onclick="copyPath(this, '{{ file_data.path }}')">📋</button>
+                    <button class="copy-btn" data-copy-path="{{ file_data.path }}">📋</button>
                 </div>
                 {% if file_data.diffs.added_lines %}
                 {% for line_data in file_data.diffs.added_lines %}
@@ -1158,7 +1158,7 @@
             <div class="file modified">
                 <div class="file-header-with-copy">
                     <h4 style="margin: 0;">{{ flaky_path }}</h4>
-                    <button class="copy-btn" onclick="copyPath(this, '{{ flaky_path }}')">📋</button>
+                    <button class="copy-btn" data-copy-path="{{ flaky_path }}">📋</button>
                 </div>
                 {% for loc in ffd.added %}
                 {{ render_flaky_location(loc, "added", project.project) }}
@@ -1180,8 +1180,8 @@
     </div>
 
     <script>
-        function copyPath(button, path) {
-            navigator.clipboard.writeText(path).then(function() {
+        function copyPath(button) {
+            navigator.clipboard.writeText(button.dataset.copyPath).then(function() {
                 // Show success feedback
                 button.textContent = '✓';
                 button.classList.add('copied');
@@ -1217,6 +1217,13 @@
         }
 
         document.addEventListener('DOMContentLoaded', function() {
+            document.querySelectorAll('.copy-btn').forEach(button => {
+                button.addEventListener('click', () => copyPath(button));
+            });
+            document.querySelectorAll('.show-more-btn').forEach(button => {
+                button.addEventListener('click', () => toggleProjectRows(button));
+            });
+
             const filterButtons = document.querySelectorAll('.filter-btn');
             const lintFilter = document.getElementById('lint-filter');
             const projectFilter = document.getElementById('project-filter');

--- a/tests/test_html_escaping.py
+++ b/tests/test_html_escaping.py
@@ -1,0 +1,169 @@
+import json
+import subprocess
+from html.parser import HTMLParser
+from pathlib import Path
+from typing import Literal
+
+import pytest
+
+from ecosystem_analyzer import diff as diff_module
+from ecosystem_analyzer.diff import DiagnosticDiff
+from ecosystem_analyzer.schema import Diagnostic, FlakyLocation, RunData, RunOutput
+
+BRANCH = "audit<svg/onload=document.title='REPORT_XSS'>"
+PATH = "src/');document.title='PATH_XSS';//<&\".py"
+
+
+class ParsedReport(HTMLParser):
+    def __init__(self, html: str) -> None:
+        super().__init__()
+        self.tags: list[tuple[str, dict[str, str | None]]] = []
+        self.text: list[str] = []
+        self.feed(html)
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        self.tags.append((tag, dict(attrs)))
+
+    def handle_data(self, data: str) -> None:
+        self.text.append(data)
+
+
+def diagnostic(path: str = PATH, message: str = "new") -> Diagnostic:
+    return {
+        "level": "error",
+        "lint_name": "invalid-argument-type",
+        "path": path,
+        "line": 1,
+        "column": 1,
+        "message": message,
+    }
+
+
+def output(
+    project: str,
+    diagnostics: list[Diagnostic],
+    flaky_diagnostics: list[FlakyLocation] | None = None,
+) -> RunOutput:
+    return {
+        "project": project,
+        "project_location": "https://github.com/example/project",
+        "strict_settings": False,
+        "ty_commit": "abc123def456",
+        "diagnostics": diagnostics,
+        "exit_statuses": [{"return_code": 1, "count": 1, "panic_messages": []}],
+        "median_time_s": 1.0,
+        "flaky_runs": 1,
+        "flaky_diagnostics": flaky_diagnostics or [],
+    }
+
+
+def make_diff(
+    tmp_path: Path, old_outputs: list[RunOutput], new_outputs: list[RunOutput]
+) -> DiagnosticDiff:
+    old_path = tmp_path / "old.json"
+    new_path = tmp_path / "new.json"
+    old_path.write_text(json.dumps(RunData(outputs=old_outputs)))
+    new_path.write_text(json.dumps(RunData(outputs=new_outputs)))
+    return DiagnosticDiff(
+        str(old_path), str(new_path), old_name=BRANCH, new_name=BRANCH
+    )
+
+
+@pytest.mark.parametrize("report_kind", ["diagnostics", "timing"])
+@pytest.mark.parametrize("use_fallback_loader", [False, True])
+def test_report_escapes_labels(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    report_kind: Literal["diagnostics", "timing"],
+    use_fallback_loader: bool,
+) -> None:
+    # This is a valid branch name, not just arbitrary invalid Git input.
+    subprocess.run(["git", "check-ref-format", "--branch", BRANCH], check=True)
+    if use_fallback_loader:
+
+        def unavailable_package_loader(*_args: str) -> None:
+            raise ImportError
+
+        monkeypatch.setattr(diff_module, "PackageLoader", unavailable_package_loader)
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "templates").symlink_to(
+            Path(diff_module.__file__).parent / "templates", target_is_directory=True
+        )
+
+    project = 'project"><svg onload="document.title=\'PROJECT_XSS\'">'
+    diff = make_diff(tmp_path, [output(project, [])], [output(project, [diagnostic()])])
+    report_path = tmp_path / "report.html"
+    if report_kind == "diagnostics":
+        diff.generate_html_report(str(report_path))
+    else:
+        diff.generate_timing_html_report(str(report_path))
+
+    report = ParsedReport(report_path.read_text())
+    assert not any(tag == "svg" for tag, _ in report.tags)
+    assert "".join(report.text).count(BRANCH) == 2
+    assert project in "".join(report.text)
+
+
+@pytest.mark.parametrize(
+    "change",
+    [
+        "added-project",
+        "removed-project",
+        "added-file",
+        "removed-file",
+        "modified-file",
+        "flaky-file",
+    ],
+)
+def test_copy_paths_are_literal_data(tmp_path: Path, change: str) -> None:
+    old_outputs = [output("project", [])]
+    new_outputs = [output("project", [diagnostic()])]
+    if change == "added-project":
+        old_outputs = []
+    elif change == "removed-project":
+        old_outputs, new_outputs = new_outputs, []
+    elif change == "removed-file":
+        old_outputs, new_outputs = new_outputs, old_outputs
+    elif change == "modified-file":
+        old_outputs = [output("project", [diagnostic(message="old")])]
+    elif change == "flaky-file":
+        new_outputs = [
+            output(
+                "project",
+                [],
+                [
+                    {
+                        "path": PATH,
+                        "line": 1,
+                        "column": 1,
+                        "variants": [{"diagnostic": diagnostic(), "count": 1}],
+                    }
+                ],
+            )
+        ]
+    diff = make_diff(tmp_path, old_outputs, new_outputs)
+    report_path = tmp_path / "report.html"
+    diff.generate_html_report(str(report_path))
+    report = ParsedReport(report_path.read_text())
+    buttons = [
+        attrs
+        for tag, attrs in report.tags
+        if tag == "button" and attrs.get("class") == "copy-btn"
+    ]
+    assert len(buttons) == 1
+    assert buttons[0]["data-copy-path"] == PATH
+    assert PATH in "".join(report.text)
+    assert not any(name.startswith("on") for _, attrs in report.tags for name in attrs)
+
+
+def test_show_more_has_no_inline_handler(tmp_path: Path) -> None:
+    diff = make_diff(
+        tmp_path,
+        [output(f"project-{index}", []) for index in range(25)],
+        [output(f"project-{index}", [diagnostic()]) for index in range(25)],
+    )
+    report_path = tmp_path / "report.html"
+    diff.generate_html_report(str(report_path))
+    report = ParsedReport(report_path.read_text())
+    assert any(attrs.get("class") == "show-more-btn" for _, attrs in report.tags)
+    assert not any(name.startswith("on") for _, attrs in report.tags for name in attrs)


### PR DESCRIPTION
Report labels, project names, and diagnostic paths can contain HTML metacharacters. The diagnostic and timing templates currently render these values without autoescaping, and copy buttons interpolate paths directly into inline JavaScript strings.

This enables Jinja autoescaping for both report types, including the fallback template loaders. Copy buttons store paths in escaped `data-copy-path` attributes and read them through static event listeners, preserving the original path literally. The show-more button also uses a static listener, leaving the diagnostic report without inline event handlers.

Adds 11 regression cases covering branch and project labels, both template loaders, all six copy-path contexts, and the show-more control. All 180 tests, type checking, and the configured checks for the changed files pass. Local Chromium checks confirmed that labels remain literal text, copying preserves a path containing quotes and HTML metacharacters, and filtering and show-more still work with a script-hash CSP that disallows inline event handlers.
