### PR TITLE
Escape HTML and restrict links in ecosystem reports

### DIFF
--- a/src/ecosystem_analyzer/ecosystem_report.py
+++ b/src/ecosystem_analyzer/ecosystem_report.py
@@ -11,6 +11,11 @@ from .schema import Diagnostic, ReportDiagnostic, RunData, RunOutput
 logger = logging.getLogger(__name__)
 
 
+def _is_http_url(value: object) -> bool:
+    """Allow only explicit HTTP(S) links in reports rendered from diagnostic JSON."""
+    return isinstance(value, str) and value.lower().startswith(("https://", "http://"))
+
+
 def _report_diagnostic(output: RunOutput, diagnostic: Diagnostic) -> ReportDiagnostic:
     report_diagnostic: ReportDiagnostic = {
         "project": output["project"],
@@ -114,14 +119,17 @@ def generate_html_report(
     # Set up Jinja2 environment with package loader
     try:
         # Try PackageLoader first (works for installed packages)
-        env = Environment(loader=PackageLoader("ecosystem_analyzer", "templates"))
+        env = Environment(
+            loader=PackageLoader("ecosystem_analyzer", "templates"), autoescape=True
+        )
     except (ImportError, FileNotFoundError):
         # Fallback to FileSystemLoader for development
         template_path = Path(__file__).parent.parent.parent / "templates"
         if not template_path.exists():
             template_path = Path("templates")
-        env = Environment(loader=FileSystemLoader(str(template_path)))
+        env = Environment(loader=FileSystemLoader(str(template_path)), autoescape=True)
 
+    env.tests["http_url"] = _is_http_url
     template = env.get_template("ecosystem_report.html")
 
     html_content = template.render(

--- a/src/ecosystem_analyzer/templates/ecosystem_report.html
+++ b/src/ecosystem_analyzer/templates/ecosystem_report.html
@@ -253,7 +253,7 @@
             ty_commit[0:7] }}</a>
         {% if flaky_project_names|length > 0 %}
         <span style="margin-left: 16px;">·</span>
-        <span style="margin-left: 16px; color: #e65100; font-weight: 600;" title="{{ flaky_project_names | join('&#10;') }}">{{ flaky_project_names|length }} flaky project{{ 's' if flaky_project_names|length != 1 }}</span>
+        <span style="margin-left: 16px; color: #e65100; font-weight: 600;" title="{{ flaky_project_names | join('\n') }}">{{ flaky_project_names|length }} flaky project{{ 's' if flaky_project_names|length != 1 }}</span>
         {% endif %}
     </div>
     {% endif %}
@@ -318,7 +318,7 @@
             <tr class="diagnostic-row{% if diagnostic.is_flaky %} is-flaky{% endif %}" data-project="{{ diagnostic.project }}" data-lint="{{ diagnostic.lint_name }}"
                 data-level="{{ diagnostic.level }}">
                 <td>
-                    {% if diagnostic.project_location %}
+                    {% if diagnostic.project_location is http_url %}
                         <a href="{{ diagnostic.project_location }}">{{ diagnostic.project }}</a>
                     {% else %}
                         {{ diagnostic.project }}
@@ -333,7 +333,7 @@
                     {% endif %}
                 </td>
                 <td>
-                    {% if diagnostic.github_ref %}
+                    {% if diagnostic.github_ref and diagnostic.github_ref is http_url %}
                         <a href="{{ diagnostic.github_ref }}" target="_blank">{{diagnostic.path}}:{{diagnostic.line}}:{{diagnostic.column}}</a>
                     {% else %}
                         {{diagnostic.path}}:{{diagnostic.line}}:{{diagnostic.column}}

--- a/tests/test_html_escaping.py
+++ b/tests/test_html_escaping.py
@@ -6,7 +6,7 @@ from typing import Literal
 
 import pytest
 
-from ecosystem_analyzer import diff as diff_module
+from ecosystem_analyzer import diff as diff_module, ecosystem_report
 from ecosystem_analyzer.diff import DiagnosticDiff
 from ecosystem_analyzer.schema import Diagnostic, FlakyLocation, RunData, RunOutput
 
@@ -167,3 +167,141 @@ def test_show_more_has_no_inline_handler(tmp_path: Path) -> None:
     report = ParsedReport(report_path.read_text())
     assert any(attrs.get("class") == "show-more-btn" for _, attrs in report.tags)
     assert not any(name.startswith("on") for _, attrs in report.tags for name in attrs)
+
+
+def make_ecosystem_report(tmp_path: Path, outputs: list[RunOutput]) -> ParsedReport:
+    diagnostics_path = tmp_path / "diagnostics.json"
+    diagnostics_path.write_text(json.dumps(RunData(outputs=outputs)))
+    report_path = tmp_path / "report.html"
+    ecosystem_report.generate(diagnostics_path, report_path)
+    return ParsedReport(report_path.read_text())
+
+
+@pytest.mark.parametrize("use_fallback_loader", [False, True])
+@pytest.mark.parametrize("flaky", [False, True])
+def test_ecosystem_report_escapes_data(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    use_fallback_loader: bool,
+    flaky: bool,
+) -> None:
+    if use_fallback_loader:
+
+        def unavailable_package_loader(*_args: str) -> None:
+            raise ImportError
+
+        monkeypatch.setattr(
+            ecosystem_report, "PackageLoader", unavailable_package_loader
+        )
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "templates").symlink_to(
+            Path(ecosystem_report.__file__).parent / "templates",
+            target_is_directory=True,
+        )
+
+    path = "<svg onload=\"document.title='PATH_XSS'\">.py"
+    project = 'project"><svg onload="document.title=\'PROJECT_XSS\'">'
+    lint = 'lint"><svg onload="document.title=\'LINT_XSS\'">'
+    message = '<script>document.title="MESSAGE_XSS"</script> & "quoted"'
+    diag = diagnostic(path=path, message=message)
+    diag["lint_name"] = lint
+    diag["github_ref"] = f"https://github.com/example/project/blob/main/{path}#L1"
+    project_output = output(project, [diag])
+    project_output["project_location"] = f"https://example.com/{project}"
+    project_output["ty_commit"] = '"><svg onload="document.title=\'COMMIT_XSS\'">'
+    if flaky:
+        other_diag = diagnostic(path=path, message=message)
+        other_diag["lint_name"] = f"other-{lint}"
+        project_output["diagnostics"] = []
+        project_output["flaky_diagnostics"] = [
+            {
+                "path": path,
+                "line": 1,
+                "column": 1,
+                "variants": [
+                    {"diagnostic": diag, "count": 1},
+                    {"diagnostic": other_diag, "count": 1},
+                ],
+            }
+        ]
+        project_output["flaky_runs"] = 2
+
+    report = make_ecosystem_report(tmp_path, [project_output])
+    assert not any(tag == "svg" for tag, _ in report.tags)
+    assert sum(tag == "script" for tag, _ in report.tags) == 1
+    assert not any(name.startswith("on") for _, attrs in report.tags for name in attrs)
+    text = "".join(report.text)
+    for value in [path, project, lint, message]:
+        assert value in text
+    row = next(attrs for _, attrs in report.tags if "data-project" in attrs)
+    assert row["data-project"] == project
+    assert row["data-lint"] == lint
+    assert any(attrs.get("value") == project for _, attrs in report.tags)
+    assert any(attrs.get("value") == lint for _, attrs in report.tags)
+    assert any(attrs.get("href") == diag["github_ref"] for _, attrs in report.tags)
+    if flaky:
+        assert f"other-{lint}" in text
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "javascript:alert(1)",
+        "JaVaScRiPt:alert(1)",
+        "\tjavascript:alert(1)",
+        "java\nscript:alert(1)",
+        "data:text/html,<script>alert(1)</script>",
+        "file:///etc/passwd",
+        "//example.com/project",
+        "javascript&#58;alert(1)",
+        "",
+    ],
+)
+def test_ecosystem_report_omits_unsafe_links(tmp_path: Path, url: str) -> None:
+    diag = diagnostic()
+    diag["github_ref"] = url
+    project_output = output("project", [diag])
+    project_output["project_location"] = url
+    report = make_ecosystem_report(tmp_path, [project_output])
+    links = [attrs["href"] for tag, attrs in report.tags if tag == "a"]
+    assert links == ["https://github.com/astral-sh/ruff/commit/abc123def456"]
+    assert "project" in "".join(report.text)
+    assert PATH in "".join(report.text)
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        'https://github.com/example/project/blob/main/a&"b.py#L1',
+        "http://example.com/project",
+        "HTTPS://example.com/project",
+    ],
+)
+def test_ecosystem_report_preserves_http_links(tmp_path: Path, url: str) -> None:
+    diag = diagnostic()
+    diag["github_ref"] = url
+    project_output = output("project", [diag])
+    project_output["project_location"] = url
+    report = make_ecosystem_report(tmp_path, [project_output])
+    links = [attrs.get("href") for tag, attrs in report.tags if tag == "a"]
+    assert links.count(url) == 2
+
+
+def test_ecosystem_report_preserves_flaky_tooltip_newlines(tmp_path: Path) -> None:
+    projects = [
+        output(
+            project,
+            [],
+            [
+                {
+                    "path": PATH,
+                    "line": 1,
+                    "column": 1,
+                    "variants": [{"diagnostic": diagnostic(), "count": 1}],
+                }
+            ],
+        )
+        for project in ["a&b", "c<d"]
+    ]
+    report = make_ecosystem_report(tmp_path, projects)
+    assert any(attrs.get("title") == "a&b\nc<d" for _, attrs in report.tags)


### PR DESCRIPTION
The full ecosystem report generated by `generate-report` still interpolates diagnostic filenames and other metadata without HTML escaping. A filename containing an HTML element with an event handler is rendered as executable markup. #180 fixed the diagnostic and timing diff reports, but did not cover this separate renderer.

Enable autoescaping for both ecosystem-report template loaders and allow only explicit HTTP(S) project/source links. Other URL schemes render as plain text. Preserve literal labels and filenames, existing message escaping, and newlines in flaky-project tooltips.

Regression tests cover stable and flaky diagnostics, both loaders, attribute escaping, unsafe URL schemes, and ordinary HTTP(S) links. Before the fix, 13 of the new cases fail.

Validation:
- `uv run --frozen pytest -q` — 197 passed
- `uv run --frozen ty check`
- `uvx prek run -a`
- Browser check: the original filename payload executes; the fixed report contains no injected SVG or event handlers, and sorting/filtering still work with escaped labels.
