### PR TITLE
Suppress removed unknown-rule diagnostics in Markdown comments

### DIFF
--- a/src/ecosystem_analyzer/diff.py
+++ b/src/ecosystem_analyzer/diff.py
@@ -1280,12 +1280,15 @@ class DiagnosticDiff:
         diff = difflib.ndiff(old_text.splitlines(), new_text.splitlines())
         return list(diff)
 
-    def _calculate_statistics(self) -> DiffStatistics:
+    def _calculate_statistics(
+        self, *, include_removed_unknown_rules: bool = True
+    ) -> DiffStatistics:
         """Calculate statistics about added, removed, and changed diagnostics.
 
         Flaky diagnostic diffs are excluded from the totals and breakdowns.
         Stable diagnostics from projects that happen to also have flaky data
-        are still counted.
+        are still counted. Markdown summaries also exclude removed unknown-rule
+        diagnostics; HTML reports retain them.
         """
         added_by_lint: Counter[str] = Counter()
         removed_by_lint: Counter[str] = Counter()
@@ -1293,6 +1296,15 @@ class DiagnosticDiff:
         added_by_project: Counter[str] = Counter()
         removed_by_project: Counter[str] = Counter()
         changed_by_project: Counter[str] = Counter()
+
+        def count_removal(project_name: str, diag: Diagnostic) -> None:
+            if (
+                not include_removed_unknown_rules
+                and diag["lint_name"] == "unknown-rule"
+            ):
+                return
+            removed_by_lint[diag["lint_name"]] += 1
+            removed_by_project[project_name] += 1
 
         # Count diagnostics from added projects
         for project in self.diffs["added_projects"]:
@@ -1305,8 +1317,7 @@ class DiagnosticDiff:
         for project in self.diffs["removed_projects"]:
             project_name = project["project"]
             for diag in project["diagnostics"]:
-                removed_by_lint[diag["lint_name"]] += 1
-                removed_by_project[project_name] += 1
+                count_removal(project_name, diag)
 
         # Count diagnostics from modified projects
         for project in self.diffs["modified_projects"]:
@@ -1320,8 +1331,7 @@ class DiagnosticDiff:
             # Removed files in modified projects
             for file_data in project["diffs"]["removed_files"]:
                 for diag in file_data["diagnostics"]:
-                    removed_by_lint[diag["lint_name"]] += 1
-                    removed_by_project[project_name] += 1
+                    count_removal(project_name, diag)
 
             # Modified files in modified projects
             for file_data in project["diffs"]["modified_files"]:
@@ -1334,8 +1344,7 @@ class DiagnosticDiff:
                 # Removed lines
                 for line_data in file_data["diffs"]["removed_lines"]:
                     for diag in line_data["diagnostics"]:
-                        removed_by_lint[diag["lint_name"]] += 1
-                        removed_by_project[project_name] += 1
+                        count_removal(project_name, diag)
 
                 # Modified lines
                 for line_data in file_data["diffs"]["modified_lines"]:
@@ -1350,8 +1359,7 @@ class DiagnosticDiff:
                         added_by_project[project_name] += 1
 
                     for diag in line_data["removed"]:
-                        removed_by_lint[diag["lint_name"]] += 1
-                        removed_by_project[project_name] += 1
+                        count_removal(project_name, diag)
 
             # Flaky location diffs are excluded from statistics — they
             # are still shown in the HTML report for manual inspection.
@@ -1520,6 +1528,16 @@ class DiagnosticDiff:
                 header = project_name
             sections.setdefault(header, []).append((lines, counts_as_change))
 
+        def add_removal(
+            project_name: str, project_location: str, diag: Diagnostic
+        ) -> None:
+            if diag["lint_name"] != "unknown-rule":
+                add_entry(
+                    project_name,
+                    project_location,
+                    [f"- {self._format_short_diagnostic(diag)}"],
+                )
+
         for project in self.diffs["failed_projects"]:
             status = project["failure_status"]
             introduced_panics = project["introduced_panic_messages"]
@@ -1581,11 +1599,7 @@ class DiagnosticDiff:
             project_name = project["project"]
             project_location = project["project_location"]
             for diag in project["diagnostics"]:
-                add_entry(
-                    project_name,
-                    project_location,
-                    [f"- {self._format_short_diagnostic(diag)}"],
-                )
+                add_removal(project_name, project_location, diag)
         for project in self.diffs["added_projects"]:
             project_name = project["project"]
             project_location = project["project_location"]
@@ -1602,11 +1616,7 @@ class DiagnosticDiff:
 
             for file_data in diffs["removed_files"]:
                 for diag in file_data["diagnostics"]:
-                    add_entry(
-                        project_name,
-                        project_location,
-                        [f"- {self._format_short_diagnostic(diag)}"],
-                    )
+                    add_removal(project_name, project_location, diag)
 
             for file_data in diffs["added_files"]:
                 for diag in file_data["diagnostics"]:
@@ -1619,11 +1629,7 @@ class DiagnosticDiff:
             for file_data in diffs["modified_files"]:
                 for line_data in file_data["diffs"]["removed_lines"]:
                     for diag in line_data["diagnostics"]:
-                        add_entry(
-                            project_name,
-                            project_location,
-                            [f"- {self._format_short_diagnostic(diag)}"],
-                        )
+                        add_removal(project_name, project_location, diag)
 
                 for line_data in file_data["diffs"]["added_lines"]:
                     for diag in line_data["diagnostics"]:
@@ -1644,11 +1650,7 @@ class DiagnosticDiff:
                             ],
                         )
                     for diag in line_data["removed"]:
-                        add_entry(
-                            project_name,
-                            project_location,
-                            [f"- {self._format_short_diagnostic(diag)}"],
-                        )
+                        add_removal(project_name, project_location, diag)
                     for diag in line_data["added"]:
                         add_entry(
                             project_name,
@@ -1671,7 +1673,7 @@ class DiagnosticDiff:
     ) -> str:
         """Render the pull-request summary of diagnostic and failure changes."""
 
-        statistics = self._calculate_statistics()
+        statistics = self._calculate_statistics(include_removed_unknown_rules=False)
         failed_projects = self.diffs["failed_projects"]
 
         markdown_content = self.generate_comment_title() + "\n\n"

--- a/tests/test_json_roundtrip.py
+++ b/tests/test_json_roundtrip.py
@@ -1924,6 +1924,116 @@ info: Args: /tmp/new_commit/ty check ."""
         assert [item["message"] for item in modified_line["removed"]] == ["babba"]
         assert modified_line["added"] == []
 
+    @pytest.mark.parametrize(
+        "context_location",
+        [
+            pytest.param(None, id="removed-project"),
+            pytest.param(("b.py", 1), id="removed-file"),
+            pytest.param(("a.py", 2), id="removed-line"),
+            pytest.param(("a.py", 1), id="modified-line"),
+        ],
+    )
+    @pytest.mark.parametrize("other_removal", [False, True])
+    def test_removed_unknown_rules_hidden_from_markdown(
+        self, context_location: tuple[str, int] | None, other_removal: bool
+    ) -> None:
+        """Hide removed unknown rules from Markdown while retaining them in HTML.
+
+        Cover removals at project, file, line, and individual diagnostic level,
+        both alone and alongside another rule's removal. Suppressed removals
+        must not affect totals, leave empty sections, or cause the raw diff to
+        be collapsed when the remaining changes fit inline.
+        """
+        unknown_rule: Diagnostic = {
+            "level": "warning",
+            "lint_name": "unknown-rule",
+            "path": "a.py",
+            "line": 1,
+            "column": 1,
+            "message": "Unknown lint rule: newly-added-rule",
+        }
+        removed: list[Diagnostic] = [unknown_rule]
+        if other_removal:
+            removed.append({
+                **unknown_rule,
+                "lint_name": "invalid-assignment",
+                "message": "Removed assignment diagnostic",
+            })
+        context: list[Diagnostic] = []
+        if context_location is not None:
+            context.append({
+                **unknown_rule,
+                "path": context_location[0],
+                "line": context_location[1],
+                "lint_name": "unresolved-reference",
+                "message": "Unchanged reference diagnostic",
+            })
+        diff = _make_diff(
+            [_make_output("proj", [*removed, *context])],
+            [_make_output("proj", context)] if context_location is not None else [],
+        )
+
+        markdown = diff.render_statistics_markdown(inline_threshold=2)
+
+        assert "unknown-rule" not in markdown
+        assert unknown_rule["message"] not in markdown
+        if other_removal:
+            assert "| `invalid-assignment` | 0 | 1 | 0 |" in markdown
+            assert "| **Total** | **0** | **1** | **0** |" in markdown
+            assert (
+                "- a.py:1:1 warning[invalid-assignment] Removed assignment diagnostic"
+                in markdown
+            )
+            assert "**Raw diff:**" in markdown
+        else:
+            assert "No diagnostic changes detected ✅" in markdown
+            assert "| Lint rule |" not in markdown
+            assert "Raw diff" not in markdown
+            assert "proj" not in markdown
+
+        assert diff._calculate_statistics()["total_removed"] == len(removed)
+        assert unknown_rule["message"] in _render_html(diff)
+
+    def test_added_and_changed_unknown_rules_remain_in_markdown(self) -> None:
+        """Keep added and rewritten unknown-rule diagnostics visible in Markdown.
+
+        Removing another diagnostic for the same rule must not hide its summary
+        row or either side of a message change, or inflate the raw diff's count.
+        """
+        old: Diagnostic = {
+            "level": "warning",
+            "lint_name": "unknown-rule",
+            "path": "a.py",
+            "line": 1,
+            "column": 1,
+            "message": "Old unknown rule message",
+        }
+        changed: Diagnostic = {**old, "message": "Changed unknown rule message"}
+        removed: Diagnostic = {
+            **old,
+            "line": 2,
+            "message": "Removed unknown rule message",
+        }
+        added: Diagnostic = {
+            **old,
+            "line": 3,
+            "message": "Added unknown rule message",
+        }
+        diff = _make_diff(
+            [_make_output("proj", [old, removed])],
+            [_make_output("proj", [changed, added])],
+        )
+
+        markdown = diff.render_statistics_markdown(inline_threshold=2)
+
+        assert "| `unknown-rule` | 1 | 0 | 1 |" in markdown
+        assert "| **Total** | **1** | **0** | **1** |" in markdown
+        assert removed["message"] not in markdown
+        assert f"- a.py:1:1 warning[unknown-rule] {old['message']}" in markdown
+        assert f"+ a.py:1:1 warning[unknown-rule] {changed['message']}" in markdown
+        assert f"+ a.py:3:1 warning[unknown-rule] {added['message']}" in markdown
+        assert "<summary>Raw diff (2 changes)</summary>" in markdown
+
     def test_statistics_markdown_includes_large_timing_changes(self) -> None:
         old_data = {
             "outputs": [


### PR DESCRIPTION
Removed `unknown-rule` diagnostics add noise to the ecosystem comment when a PR introduces a lint rule.

Exclude these removals from the Markdown summary table and raw diff, including totals and raw-diff change counts. Keep added and rewritten `unknown-rule` diagnostics visible, and retain all removals in the HTML report.
